### PR TITLE
Refactor dashboard to modern statistics dashboard

### DIFF
--- a/lib/widgets/status/statistics_dashboard/components/dashboard_card.dart
+++ b/lib/widgets/status/statistics_dashboard/components/dashboard_card.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import "../../../../config.dart";
+
+class DashboardCard extends StatelessWidget {
+  final Widget child;
+  const DashboardCard({required this.child, super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 4,
+      color: AppColor.niceblack,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Padding(
+        padding: const EdgeInsets.all(10),
+        child: child,
+      ),
+    );
+  }
+}

--- a/lib/widgets/status/statistics_dashboard/components/global_statistics_list.dart
+++ b/lib/widgets/status/statistics_dashboard/components/global_statistics_list.dart
@@ -1,15 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:fr0gsite/chainactions/statisticactions.dart';
 import 'package:fr0gsite/datatypes/statistics.dart';
+import 'dashboard_card.dart';
 
-class Statisticglobalaslist extends StatefulWidget {
-  const Statisticglobalaslist({super.key});
+class GlobalStatisticsList extends StatefulWidget {
+  const GlobalStatisticsList({super.key});
 
   @override
-  State<Statisticglobalaslist> createState() => _StatisticglobalaslistState();
+  State<GlobalStatisticsList> createState() => _GlobalStatisticsListState();
 }
 
-class _StatisticglobalaslistState extends State<Statisticglobalaslist> {
+class _GlobalStatisticsListState extends State<GlobalStatisticsList> {
   late Future globalstatistics;
 
   @override
@@ -20,11 +21,12 @@ class _StatisticglobalaslistState extends State<Statisticglobalaslist> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        const Text("Global statistics", style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
-        Expanded(
-          child: FutureBuilder(
+    return DashboardCard(
+      child: Column(
+        children: [
+          const Text("Global statistics", style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+          Expanded(
+            child: FutureBuilder(
             future: globalstatistics,
             builder: (BuildContext context, AsyncSnapshot snapshot) {
               if (snapshot.connectionState == ConnectionState.done) {

--- a/lib/widgets/status/statistics_dashboard/components/report_status_pie_chart.dart
+++ b/lib/widgets/status/statistics_dashboard/components/report_status_pie_chart.dart
@@ -4,16 +4,17 @@ import 'package:fr0gsite/chainactions/statisticactions.dart';
 import 'package:fr0gsite/config.dart';
 import 'package:fr0gsite/datatypes/report.dart';
 import 'package:fr0gsite/datatypes/statistics.dart';
+import 'dashboard_card.dart';
 // Für den einfachen Zugriff auf math Funktionen
 
-class StatisticReportStatusPieDiagramm extends StatefulWidget {
-  const StatisticReportStatusPieDiagramm({super.key});
+class ReportStatusPieChart extends StatefulWidget {
+  const ReportStatusPieChart({super.key});
 
   @override
-  State<StatisticReportStatusPieDiagramm> createState() => _StatisticReportStatusPieDiagrammState();
+  State<ReportStatusPieChart> createState() => _ReportStatusPieChartState();
 }
 
-class _StatisticReportStatusPieDiagrammState extends State<StatisticReportStatusPieDiagramm>
+class _ReportStatusPieChartState extends State<ReportStatusPieChart>
     with SingleTickerProviderStateMixin {
   List<Report> reportlist = [];
   late Future globalstatistics;
@@ -40,21 +41,17 @@ class _StatisticReportStatusPieDiagrammState extends State<StatisticReportStatus
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        const Text("Action Pie", style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
-        Expanded(
-          child: FutureBuilder(
+    return DashboardCard(
+      child: Column(
+        children: [
+          const Text("Action Pie", style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+          Expanded(
+            child: FutureBuilder(
             future: globalstatistics,
             builder: (BuildContext context, AsyncSnapshot snapshot) {
               if (snapshot.connectionState == ConnectionState.done) {
                 if (snapshot.hasData && snapshot.data.isNotEmpty) {
-                  return Card(
-                    elevation: 4,
-                    color: AppColor.niceblack,
-                    child: Padding(
-                      padding: const EdgeInsets.all(10),
-                      child: AnimatedBuilder(
+                  return AnimatedBuilder(
                         animation: _rotationController,
                         builder: (context, child) {
                           final rotationDegrees = 360 * _rotationController.value;
@@ -86,9 +83,7 @@ class _StatisticReportStatusPieDiagrammState extends State<StatisticReportStatus
                             ),
                           );
                         },
-                      ),
-                    ),
-                  );
+                      );
                 } else {
                   return const Center(child: Text('No data available'));
                 }
@@ -107,3 +102,4 @@ class _StatisticReportStatusPieDiagrammState extends State<StatisticReportStatus
     return statistics;
   }
 }
+

--- a/lib/widgets/status/statistics_dashboard/components/truster_statistics.dart
+++ b/lib/widgets/status/statistics_dashboard/components/truster_statistics.dart
@@ -5,15 +5,16 @@ import 'package:fr0gsite/datatypes/truster.dart';
 import 'package:fr0gsite/nameconverter.dart';
 import 'package:fr0gsite/l10n/app_localizations.dart';
 import 'package:intl/intl.dart';
+import 'dashboard_card.dart';
 
-class StatisticTrusterList extends StatefulWidget {
-  const StatisticTrusterList({super.key});
+class TrusterStatistics extends StatefulWidget {
+  const TrusterStatistics({super.key});
 
   @override
-  State<StatisticTrusterList> createState() => _StatisticTrusterListState();
+  State<TrusterStatistics> createState() => _TrusterStatisticsState();
 }
 
-class _StatisticTrusterListState extends State<StatisticTrusterList> {
+class _TrusterStatisticsState extends State<TrusterStatistics> {
   List<Truster> trusterlist = [];
   List<DataRow> dataRow = [];
   bool sortAscending = true;
@@ -51,9 +52,7 @@ class _StatisticTrusterListState extends State<StatisticTrusterList> {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      elevation: 4,
-      color: AppColor.niceblack,
+    return DashboardCard(
       child: Center(
         child: SingleChildScrollView(
           child: Padding(

--- a/lib/widgets/status/statistics_dashboard/statistics_dashboard.dart
+++ b/lib/widgets/status/statistics_dashboard/statistics_dashboard.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:fr0gsite/config.dart';
-import 'package:fr0gsite/widgets/status/dashboard/views/statisticglobalaslist.dart';
-import 'package:fr0gsite/widgets/status/dashboard/views/statisticreportstatuspiediagramm.dart';
-import 'package:fr0gsite/widgets/status/dashboard/views/statistictruster.dart';
+import 'package:fr0gsite/widgets/status/statistics_dashboard/components/global_statistics_list.dart';
+import 'package:fr0gsite/widgets/status/statistics_dashboard/components/report_status_pie_chart.dart';
+import 'package:fr0gsite/widgets/status/statistics_dashboard/components/truster_statistics.dart';
 
-class DashboardWidget extends StatelessWidget {
-  const DashboardWidget({super.key});
+class StatisticsDashboard extends StatelessWidget {
+  const StatisticsDashboard({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -22,9 +22,9 @@ class DashboardWidget extends StatelessWidget {
                 mainAxisSpacing: 10,
                 padding: const EdgeInsets.all(10),
                 children: const [
-                  StatisticTrusterList(),
-                  StatisticReportStatusPieDiagramm(),
-                  Statisticglobalaslist(),
+                  TrusterStatistics(),
+                  ReportStatusPieChart(),
+                  GlobalStatisticsList(),
                 ],
               ),
             ),

--- a/lib/widgets/status/status.dart
+++ b/lib/widgets/status/status.dart
@@ -1,5 +1,5 @@
 import 'package:fr0gsite/config.dart';
-import 'package:fr0gsite/widgets/status/dashboard/dashboardwidget.dart';
+import 'package:fr0gsite/widgets/status/statistics_dashboard/statistics_dashboard.dart';
 import 'package:fr0gsite/widgets/status/producervote.dart';
 import 'package:fr0gsite/widgets/status/transactiontimeline.dart';
 import 'package:flutter/material.dart';
@@ -23,7 +23,7 @@ class StatusState extends State<Status> {
   List<Widget> widgetOptions = <Widget>[
     const Expanded(child: TransactionTimeline()),
     const Expanded(child: Producervote()),
-    const Expanded(child: DashboardWidget()),
+    const Expanded(child: StatisticsDashboard()),
   ];
 
   @override


### PR DESCRIPTION
## Summary
- rename dashboard folder to `statistics_dashboard`
- add `DashboardCard` to unify section styling
- rename statistics widgets to `GlobalStatisticsList`, `TrusterStatistics`, and `ReportStatusPieChart`
- update references in `Status` widget

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68631d0d3a108324914b292f14f10b48