### PR TITLE
Add widget test for NameConverter

### DIFF
--- a/test/sample_test.dart
+++ b/test/sample_test.dart
@@ -1,9 +1,11 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:fr0gsite/nameconverter.dart';
 
 void main() {
-  test('Example test', () {
-    // Test code goes here
-    // Use assertions to verify the expected behavior
-    expect(2 + 2, equals(4));
+  testWidgets('NameConverter converts back and forth', (tester) async {
+    const name = 'helloworld1';
+    final value = NameConverter.nameToUint64(name);
+    final result = NameConverter.uint64ToName(value);
+    expect(result, equals(name));
   });
 }


### PR DESCRIPTION
## Summary
- replace unit test with widget test
- verify NameConverter round-trip conversion

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686451a739688324a2631f650e0b3a73