### PR TITLE
Add debug auto login

### DIFF
--- a/lib/config.dart
+++ b/lib/config.dart
@@ -152,6 +152,13 @@ class AppConfig {
   static const String secureStorageusername = "username";
   static const String secureStorageUserConfig = "userconfig";
 
+  // Debug login credentials
+  // Provide values here if you want the app to automatically
+  // log in while running in debug mode.
+  static const String debugUsername = ""; // e.g. "testuser"
+  static const String debugPKey = ""; // private key of debug account
+  static const String debugPermission = "active";
+
   static const connectioncheckinterval = 60; //in seconds
   static int refreshuserfavoriteupload = 15; //in minutes
   static int refreshuserfavoritecomment = 15; //in minutes

--- a/lib/localstorage.dart
+++ b/lib/localstorage.dart
@@ -6,6 +6,7 @@ import 'package:fr0gsite/datatypes/localuserconfig.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:provider/provider.dart';
+import 'package:flutter/foundation.dart';
 
 loginwhencredentialsarestored(context) async {
   if (Provider.of<GlobalStatus>(context, listen: false).isLoggedin) {
@@ -30,6 +31,30 @@ loginwhencredentialsarestored(context) async {
         debugPrint("No username found in secure storage");
       }
     });
+  }
+}
+
+/// Automatically log in when running in debug mode.
+///
+/// If [AppConfig.debugUsername] and [AppConfig.debugPKey] are set,
+/// the app will log in with these credentials when [kDebugMode] is true
+/// and no user is currently logged in.
+debugAutoLogin(context) async {
+  if (kDebugMode &&
+      !Provider.of<GlobalStatus>(context, listen: false).isLoggedin) {
+    if (AppConfig.debugUsername.isNotEmpty &&
+        AppConfig.debugPKey.isNotEmpty) {
+      debugPrint('Debug auto login for ${AppConfig.debugUsername}');
+      const secstorage = FlutterSecureStorage();
+      await secstorage.write(
+          key: AppConfig.secureStorageusername,
+          value: AppConfig.debugUsername);
+      await secstorage.write(
+          key: AppConfig.secureStoragePKey,
+          value: AppConfig.debugPKey);
+      Provider.of<GlobalStatus>(context, listen: false)
+          .login(AppConfig.debugUsername, AppConfig.debugPermission);
+    }
   }
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -177,6 +177,7 @@ class StartPoint extends State<Fr0gsiteApp> {
       (_) {
         //Check if there are any saved credentials
         loginwhencredentialsarestored(context);
+        debugAutoLogin(context);
         if (navigationRailwidth == 0.0) {
           setState(
             () {


### PR DESCRIPTION
## Summary
- implement debug auto login function
- add debug credentials placeholders in configuration
- auto login in debug mode after app start

## Testing
- `flutter test test/sample_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686451fa86c88324a349503b2e3c24e2