### PR TITLE
Fix context usage after async dialogs

### DIFF
--- a/lib/widgets/resources/resourcebalance.dart
+++ b/lib/widgets/resources/resourcebalance.dart
@@ -285,20 +285,21 @@ class _ResourceBalanceState extends State<ResourceBalance>
                             borderRadius: BorderRadius.circular(8),
                             ),
                           ),
-                          onPressed: () {
-                            showDialog(
-                                context: context,
-                                barrierDismissible: true,
-                                barrierColor: Colors.black.withOpacity(0.5),
-                                builder: (BuildContext context) {
-                                  return Dialog(
-                                    child: StakeorUnstake(
-                                        action: "Stake", account: widget.account),
-                                  );
-                                }).then((value) {
-                              debugPrint("Dialog closed");
-                              widget.callback();
-                            });
+                          onPressed: () async {
+                            await showDialog(
+                              context: context,
+                              barrierDismissible: true,
+                              barrierColor: Colors.black.withOpacity(0.5),
+                              builder: (BuildContext context) {
+                                return Dialog(
+                                  child: StakeorUnstake(
+                                      action: "Stake", account: widget.account),
+                                );
+                              },
+                            );
+                            if (!mounted) return;
+                            debugPrint("Dialog closed");
+                            widget.callback();
                           },
                           child: Text(AppLocalizations.of(context)!.stake,
                               overflow: TextOverflow.ellipsis,
@@ -317,21 +318,21 @@ class _ResourceBalanceState extends State<ResourceBalance>
                             borderRadius: BorderRadius.circular(8),
                             ),
                           ),
-                          onPressed: () {
-                            showDialog(
-                                context: context,
-                                barrierDismissible: true,
-                                barrierColor: Colors.black.withOpacity(0.5),
-                                builder: (BuildContext context) {
-                                  return Dialog(
-                                    child: StakeorUnstake(
-                                        action: "Unstake",
-                                        account: widget.account),
-                                  );
-                                }).then((value) {
-                              debugPrint("Dialog closed");
-                              widget.callback();
-                            });
+                          onPressed: () async {
+                            await showDialog(
+                              context: context,
+                              barrierDismissible: true,
+                              barrierColor: Colors.black.withOpacity(0.5),
+                              builder: (BuildContext context) {
+                                return Dialog(
+                                  child: StakeorUnstake(
+                                      action: "Unstake", account: widget.account),
+                                );
+                              },
+                            );
+                            if (!mounted) return;
+                            debugPrint("Dialog closed");
+                            widget.callback();
                           },
                           child: Text(AppLocalizations.of(context)!.unstake,
                               overflow: TextOverflow.ellipsis,


### PR DESCRIPTION
## Summary
- address VS Code `use_build_context_synchronously` lints
- refactor stake/unstake buttons to await dialog and check `mounted`

## Testing
- `apt-get update`
- *(tests omitted: flutter command not available)*

------
https://chatgpt.com/codex/tasks/task_e_6864e81dfedc8324b63f5f3559a34160