### PR TITLE
Add world map statistics widget

### DIFF
--- a/lib/widgets/status/statistics_dashboard/components/world_map_statistics.dart
+++ b/lib/widgets/status/statistics_dashboard/components/world_map_statistics.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:world_map/world_map.dart';
+import '../../../../config.dart';
+import 'dashboard_card.dart';
+
+class WorldMapStatistics extends StatefulWidget {
+  const WorldMapStatistics({super.key});
+
+  @override
+  State<WorldMapStatistics> createState() => _WorldMapStatisticsState();
+}
+
+class _WorldMapStatisticsState extends State<WorldMapStatistics> {
+  late final SimpleMapController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = SimpleMapController();
+    _controller.points = [
+      SimpleMapPoint(lat: 47.5596, lng: 7.5886, color: Colors.red, radius: 4),
+      SimpleMapPoint(lat: 35.6895, lng: 139.6917, color: Colors.red, radius: 4),
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DashboardCard(
+      child: Column(
+        children: [
+          const Text('World Map',
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+          Expanded(
+            child: SimpleMap(
+              controller: _controller,
+              options: SimpleMapOptions(
+                mapAsset: 'packages/world_map/assets/map.png',
+                mapColor: AppColor.nicewhite,
+                bgColor: AppColor.niceblack,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/status/statistics_dashboard/statistics_dashboard.dart
+++ b/lib/widgets/status/statistics_dashboard/statistics_dashboard.dart
@@ -4,6 +4,7 @@ import 'package:fr0gsite/config.dart';
 import 'package:fr0gsite/widgets/status/statistics_dashboard/components/global_statistics_list.dart';
 import 'package:fr0gsite/widgets/status/statistics_dashboard/components/report_status_pie_chart.dart';
 import 'package:fr0gsite/widgets/status/statistics_dashboard/components/truster_statistics.dart';
+import 'package:fr0gsite/widgets/status/statistics_dashboard/components/world_map_statistics.dart';
 
 class StatisticsDashboard extends StatelessWidget {
   const StatisticsDashboard({super.key});
@@ -25,6 +26,7 @@ class StatisticsDashboard extends StatelessWidget {
                   TrusterStatistics(),
                   ReportStatusPieChart(),
                   GlobalStatisticsList(),
+                  WorldMapStatistics(),
                 ],
               ),
             ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -84,6 +84,7 @@ dependencies:
   #universal_io: ^2.2.0
   #qr_code_scanner: ^1.0.1
   #geolocator 9.0.2 #Get user location for language selection
+  world_map: ^1.0.0
 
 
   convert: any


### PR DESCRIPTION
## Summary
- add `world_map` package as dependency
- create `WorldMapStatistics` widget showing Basel and Tokyo
- include world map widget in the dashboard

## Testing
- `flutter test test/sample_test.dart` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653066d5548324957f9b04c7486ef3