### PR TITLE
Add ActionBoard widget in TrusterView

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -369,5 +369,9 @@
   "important": "Wichtig",
   "selectedrule": "Ausgewählte Regel",
   "votes": "Stimmen",
-  "stakedtotal": "Total Staked"
+  "stakedtotal": "Total Staked",
+  "actionboard": "Aktionsübersicht",
+  "actionboardreviewdesc": "Zeigt alle offenen Meldungen",
+  "actionboardstatusdesc": "Aktuellen Status ansehen",
+  "actionboardsettingsdesc": "Truster-Einstellungen öffnen"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -415,6 +415,10 @@
     "important":"Important",
     "selectedrule":"Selected Rule",
     "votes":"Votes",
-    "stakedtotal":"Total Staked"
+    "stakedtotal":"Total Staked",
+    "actionboard":"Action Board",
+    "actionboardreviewdesc":"See all open reports",
+    "actionboardstatusdesc":"View your current status",
+    "actionboardsettingsdesc":"Open truster settings"
 
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2347,6 +2347,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Total Staked'**
   String get stakedtotal;
+
+  /// No description provided for @actionboard.
+  ///
+  /// In en, this message translates to:
+  /// **'Action Board'**
+  String get actionboard;
+
+  /// No description provided for @actionboardreviewdesc.
+  ///
+  /// In en, this message translates to:
+  /// **'See all open reports'**
+  String get actionboardreviewdesc;
+
+  /// No description provided for @actionboardstatusdesc.
+  ///
+  /// In en, this message translates to:
+  /// **'View your current status'**
+  String get actionboardstatusdesc;
+
+  /// No description provided for @actionboardsettingsdesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Open truster settings'**
+  String get actionboardsettingsdesc;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1177,4 +1177,16 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get stakedtotal => 'Total Staked';
+
+  @override
+  String get actionboard => 'Aktionsübersicht';
+
+  @override
+  String get actionboardreviewdesc => 'Zeigt alle offenen Meldungen';
+
+  @override
+  String get actionboardstatusdesc => 'Aktuellen Status ansehen';
+
+  @override
+  String get actionboardsettingsdesc => 'Truster-Einstellungen öffnen';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1167,4 +1167,16 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get stakedtotal => 'Total Staked';
+
+  @override
+  String get actionboard => 'Action Board';
+
+  @override
+  String get actionboardreviewdesc => 'See all open reports';
+
+  @override
+  String get actionboardstatusdesc => 'View your current status';
+
+  @override
+  String get actionboardsettingsdesc => 'Open truster settings';
 }

--- a/lib/widgets/truster/actionboard.dart
+++ b/lib/widgets/truster/actionboard.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:fr0gsite/l10n/app_localizations.dart';
+
+class ActionBoard extends StatelessWidget {
+  const ActionBoard({super.key});
+
+  void _notImplemented(BuildContext context) {
+    ScaffoldMessenger.of(context)
+        .showSnackBar(const SnackBar(content: Text('Not implemented')));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: Colors.black,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(20),
+        side: const BorderSide(color: Colors.white, width: 2),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              AppLocalizations.of(context)!.actionboard,
+              style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 12),
+            _buildAction(
+              context,
+              icon: Icons.list_alt,
+              label: AppLocalizations.of(context)!.openreport,
+              description:
+                  AppLocalizations.of(context)!.actionboardreviewdesc,
+            ),
+            const SizedBox(height: 8),
+            _buildAction(
+              context,
+              icon: Icons.star,
+              label: AppLocalizations.of(context)!.changestatus,
+              description:
+                  AppLocalizations.of(context)!.actionboardstatusdesc,
+            ),
+            const SizedBox(height: 8),
+            _buildAction(
+              context,
+              icon: Icons.settings,
+              label: AppLocalizations.of(context)!.settings,
+              description:
+                  AppLocalizations.of(context)!.actionboardsettingsdesc,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAction(
+    BuildContext context, {
+    required IconData icon,
+    required String label,
+    required String description,
+  }) {
+    return Row(
+      children: [
+        ElevatedButton(
+          onPressed: () => _notImplemented(context),
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.blue.withOpacity(0.3),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(10),
+            ),
+          ),
+          child: Row(
+            children: [
+              Icon(icon, color: Colors.white),
+              const SizedBox(width: 8),
+              Text(label, style: const TextStyle(color: Colors.white)),
+            ],
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            description,
+            style: const TextStyle(color: Colors.white70),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/truster/trusterview.dart
+++ b/lib/widgets/truster/trusterview.dart
@@ -1,6 +1,7 @@
 import 'package:fr0gsite/config.dart';
 import 'package:fr0gsite/widgets/truster/trustercaseoverview.dart';
 import 'package:fr0gsite/widgets/truster/trusterconfigview.dart';
+import 'package:fr0gsite/widgets/truster/actionboard.dart';
 import 'package:flutter/material.dart';
 
 class TrusterView extends StatefulWidget {
@@ -77,6 +78,11 @@ class TrusterViewState extends State<TrusterView> {
                           height: 600,
                           width: 600,
                           child: StatusOverview(),
+                        ),
+                        SizedBox(
+                          height: 220,
+                          width: 600,
+                          child: ActionBoard(),
                         ),
                       ],
                     ),


### PR DESCRIPTION
## Summary
- add new `ActionBoard` widget with three sample actions
- integrate `ActionBoard` into `TrusterView`
- add German and English translations for ActionBoard texts
- update localization files with new getters

## Testing
- `flutter test` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865954342d48324831303007316ac9f