### PR TITLE
Fix overflow in TrusterVoteReportView

### DIFF
--- a/lib/widgets/truster/trustervotereportview.dart
+++ b/lib/widgets/truster/trustervotereportview.dart
@@ -102,7 +102,7 @@ class _TrusterVoteReportViewState extends State<TrusterVoteReportView> {
                     ),
                     const SizedBox(height: 20),
                     SizedBox(
-                      height: 600,
+                      height: MediaQuery.of(context).size.height * 0.6,
                       child: SwipeItem(upload: upload)),
                     const SizedBox(height: 20),
                     Row(
@@ -136,7 +136,7 @@ class _TrusterVoteReportViewState extends State<TrusterVoteReportView> {
                         final votes = votesSnapshot.data!;
 
                         return SizedBox(
-                          width: 600,
+                          width: double.infinity,
                           child: Table(
                             border: TableBorder.all(),
                             defaultColumnWidth: const FixedColumnWidth(100),


### PR DESCRIPTION
## Summary
- prevent vertical overflow by making the postviewer height responsive
- let the votes table expand to available width

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686597d9fa308324a0915780c1e90a83