### PR TITLE
Postviewer info from reports

### DIFF
--- a/lib/widgets/postviewer/postviewer.dart
+++ b/lib/widgets/postviewer/postviewer.dart
@@ -10,6 +10,7 @@ import 'package:fr0gsite/widgets/postviewer/postvieweranimation.dart';
 import 'package:fr0gsite/widgets/postviewer/tagbarview.dart';
 import 'package:fr0gsite/widgets/postviewer/overlaywidgetbasic.dart';
 import 'package:fr0gsite/widgets/postviewer/comment/commentbar.dart';
+import 'package:fr0gsite/widgets/postviewer/comment/uploadinfo.dart';
 import 'package:fr0gsite/widgets/postviewer/postviewertopbar.dart';
 import 'package:fr0gsite/widgets/postviewer/swipeitem.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
@@ -24,7 +25,8 @@ import 'postviewerbottombar.dart';
 
 class Postviewer extends StatefulWidget {
   final String? id;
-  const Postviewer({super.key, this.id});
+  final bool showUploadInfo;
+  const Postviewer({super.key, this.id, this.showUploadInfo = false});
 
   @override
   PostviewerState createState() => PostviewerState();
@@ -195,8 +197,16 @@ class PostviewerState extends State<Postviewer> {
                                     ),
                             );
                           }),
-                          const SizedBox(
-                              height: 60, child: PostViewerBottomBar()),
+                          widget.showUploadInfo
+                              ? SizedBox(
+                                  height: 200,
+                                  child: Consumer<PostviewerStatus>(
+                                      builder: (context, status, child) {
+                                    return UploadInfo(
+                                        upload: status.currentupload);
+                                  }))
+                              : const SizedBox(
+                                  height: 60, child: PostViewerBottomBar()),
                         ],
                       ),
                     ),

--- a/lib/widgets/truster/trustercaseoverview.dart
+++ b/lib/widgets/truster/trustercaseoverview.dart
@@ -4,6 +4,7 @@ import 'package:fr0gsite/config.dart';
 import 'package:fr0gsite/datatypes/globalstatus.dart';
 import 'package:fr0gsite/datatypes/report.dart';
 import 'package:fr0gsite/ipfsactions.dart';
+import 'package:fr0gsite/widgets/postviewer/postviewer.dart';
 import 'package:fr0gsite/widgets/truster/trustervotereportview.dart';
 import 'package:provider/provider.dart';
 import 'package:fr0gsite/l10n/app_localizations.dart';
@@ -200,9 +201,17 @@ class ReportsTable extends StatelessWidget {
                       UploadThumb(uploadId: report.id),
                       const SizedBox(width: 4),
                       InkWell(
-                        child: Text('${report.id}', style: const TextStyle(color: Colors.blue)),
+                        child: Text('${report.id}',
+                            style: const TextStyle(color: Colors.blue)),
                         onTap: () {
-                          // Link zum Upload
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => Postviewer(
+                                  id: report.id.toString(),
+                                  showUploadInfo: true),
+                            ),
+                          );
                         },
                       ),
                     ],


### PR DESCRIPTION
## Summary
- allow Postviewer to optionally show upload info instead of the bottom bar
- open Postviewer with that option from truster case overview when tapping an upload id

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68659e0cb980832487f03c3172b1984a