### PR TITLE
Unify StatusOverview style

### DIFF
--- a/lib/widgets/truster/trusterconfigview.dart
+++ b/lib/widgets/truster/trusterconfigview.dart
@@ -1,33 +1,43 @@
 import 'package:flutter/material.dart';
 import 'package:fr0gsite/l10n/app_localizations.dart';
+import 'package:fr0gsite/config.dart';
 
 class StatusOverview extends StatelessWidget {
   const StatusOverview({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.black,
-      appBar: AppBar(
-        backgroundColor: Colors.black,
-        foregroundColor: Colors.white,
-        title: const Text('Your Status'),
-        leading: const BackButton(),
+    return Card(
+      color: AppColor.niceblack,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(20),
+        side: const BorderSide(color: Colors.white, width: 2),
       ),
-      body: SingleChildScrollView(
+      child: SingleChildScrollView(
         padding: const EdgeInsets.all(16.0),
         child: Column(
-          crossAxisAlignment: CrossAxisAlignment.end,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            ElevatedButton(
-              onPressed: () {},
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.redAccent,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(20),
+            Text(
+              AppLocalizations.of(context)!.status,
+              style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerRight,
+              child: ElevatedButton(
+                onPressed: () {},
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.redAccent,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(20),
+                  ),
                 ),
+                child: Text(AppLocalizations.of(context)!.changestatus),
               ),
-              child:  Text(AppLocalizations.of(context)!.changestatus),
             ),
             const SizedBox(height: 20),
             Row(


### PR DESCRIPTION
## Summary
- adjust `StatusOverview` layout in `trusterconfigview.dart` to use a card
- add headline and align action button

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a5236f60832498e79a84b8a4defc