### PR TITLE
Show Impressum via popup

### DIFF
--- a/lib/widgets/infoscreens/impressum.dart
+++ b/lib/widgets/infoscreens/impressum.dart
@@ -1,14 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 
-class ImpressumPage extends StatefulWidget {
-  const ImpressumPage({super.key});
+import '../../config.dart';
+
+/// Popup dialog displaying the contents of the local `impressum.txt` file.
+class ImpressumView extends StatefulWidget {
+  const ImpressumView({super.key});
 
   @override
-  State<ImpressumPage> createState() => _ImpressumPageState();
+  State<ImpressumView> createState() => _ImpressumViewState();
 }
 
-class _ImpressumPageState extends State<ImpressumPage> {
+class _ImpressumViewState extends State<ImpressumView> {
   String _content = '';
 
   @override
@@ -22,7 +25,8 @@ class _ImpressumPageState extends State<ImpressumPage> {
       _content = await rootBundle.loadString('assets/impressum.txt');
     } catch (_) {
       try {
-        _content = await rootBundle.loadString('assets/impressum.template.txt');
+        _content =
+            await rootBundle.loadString('assets/impressum.template.txt');
       } catch (_) {
         _content = 'Impressum konnte nicht geladen werden.';
       }
@@ -32,16 +36,55 @@ class _ImpressumPageState extends State<ImpressumPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Impressum'),
-      ),
-      body: _content.isEmpty
-          ? const Center(child: CircularProgressIndicator())
-          : Padding(
-              padding: const EdgeInsets.all(16),
-              child: SingleChildScrollView(child: Text(_content)),
+    return Stack(
+      children: [
+        GestureDetector(
+          onTap: () => Navigator.pop(context),
+          child: Container(
+            color: Colors.black38,
+            width: double.infinity,
+            height: double.infinity,
+          ),
+        ),
+        Center(
+          child: SizedBox(
+            width: 600,
+            height: 600,
+            child: Material(
+              color: AppColor.nicegrey,
+              shape: const RoundedRectangleBorder(
+                borderRadius: BorderRadius.all(Radius.circular(20.0)),
+                side: BorderSide(
+                    color: Colors.white, width: 6, strokeAlign: 4.0),
+              ),
+              child: Scaffold(
+                backgroundColor: Colors.transparent,
+                appBar: AppBar(
+                  backgroundColor: AppColor.nicegrey,
+                  elevation: 0,
+                  automaticallyImplyLeading: false,
+                  leading: IconButton(
+                    icon: const Icon(Icons.close, color: Colors.white),
+                    onPressed: () => Navigator.pop(context),
+                  ),
+                  title: const Text('Impressum'),
+                  centerTitle: true,
+                ),
+                body: _content.isEmpty
+                    ? const Center(child: CircularProgressIndicator())
+                    : Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: SingleChildScrollView(
+                            child: Text(
+                          _content,
+                          style: const TextStyle(color: Colors.white),
+                        )),
+                      ),
+              ),
             ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/widgets/infoscreens/informations.dart
+++ b/lib/widgets/infoscreens/informations.dart
@@ -6,6 +6,7 @@ import 'package:fr0gsite/l10n/app_localizations.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../../config.dart';
 import '../../datatypes/globalstatus.dart';
+import 'impressum.dart';
 
 class Informations extends StatefulWidget {
   const Informations({super.key});
@@ -114,7 +115,10 @@ class _InformationsState extends State<Informations> {
                       title: const Text('Impressum'),
                       leading: const Icon(Icons.info_outline),
                       onPressed: (BuildContext context) {
-                        Navigator.pushNamed(context, '/impressum');
+                        showDialog(
+                          context: context,
+                          builder: (_) => const ImpressumView(),
+                        );
                       },
                     ),
                   ],

--- a/lib/widgets/routes.dart
+++ b/lib/widgets/routes.dart
@@ -1,6 +1,5 @@
 import 'package:fr0gsite/widgets/globaltag/globaltag.dart';
 import 'package:fr0gsite/widgets/infoscreens/informations.dart';
-import 'package:fr0gsite/widgets/infoscreens/impressum.dart';
 import 'package:fr0gsite/widgets/infoscreens/notfoundpage.dart';
 import 'package:fr0gsite/widgets/postviewer/postviewer.dart';
 import 'package:fr0gsite/widgets/profile/profile.dart';
@@ -28,9 +27,6 @@ class Mainrouter {
   static final Handler _notfoundpage = Handler(
       handlerFunc: (context, Map<String, dynamic> params) =>
           const NotFoundPage());
-  static final Handler _impressumPage = Handler(
-      handlerFunc: (context, Map<String, dynamic> params) =>
-          const ImpressumPage());
 
   static final Handler _informationPage = Handler(
       handlerFunc: (context, Map<String, dynamic> params) =>
@@ -61,7 +57,6 @@ class Mainrouter {
     router.define('loadingpleasewaitscreen', handler: _loadingpleasewaitscreen);
 
     router.define('/informations', handler: _informationPage);
-    router.define('/impressum', handler: _impressumPage);
 
     router.define('/profile/:username',
         handler: _profile, transitionType: TransitionType.none);


### PR DESCRIPTION
## Summary
- refactor Impressum screen into popup dialog
- open Impressum dialog from information page
- drop obsolete Impressum route

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b59fefa34832482f0bb2fa0626ca1