### PR TITLE
Enable swipe navigation for home tabs

### DIFF
--- a/lib/widgets/home/home.dart
+++ b/lib/widgets/home/home.dart
@@ -19,25 +19,26 @@ class Home extends StatefulWidget {
   State<Home> createState() => _HomeState();
 }
 
-class _HomeState extends State<Home> {
+class _HomeState extends State<Home> with TickerProviderStateMixin {
   int currenttabindex = 0;
+  late TabController tabController;
   ScrollController homescrollcontroller = ScrollController();
 
   @override
   void initState() {
     super.initState();
-    Provider.of<GlobalStatus>(context, listen: false).expandhomenavigationbar =
-        true;
-  }
-
-  void tabbarPressed(int index) {
-    if(index == currenttabindex) {
-      return; // No need to update the state if the same tab is pressed again
-    }
-    setState(() {
-      currenttabindex = index;
+    Provider.of<GlobalStatus>(context, listen: false).expandhomenavigationbar = true;
+    tabController = TabController(length: 4, vsync: this);
+    tabController.addListener(() {
+      if (tabController.indexIsChanging) return;
+      if (currenttabindex != tabController.index) {
+        setState(() {
+          currenttabindex = tabController.index;
+        });
+      }
     });
   }
+
 
   @override
   Widget build(BuildContext context) {
@@ -61,8 +62,17 @@ class _HomeState extends State<Home> {
             SizedBox(
               height: 1000,
               child: Container(
-                  color: AppColor.nicegrey,
-                  child: HomeCubeList(currenttabindex: currenttabindex)),
+                color: AppColor.nicegrey,
+                child: TabBarView(
+                  controller: tabController,
+                  children: const [
+                    HomeCubeList(currenttabindex: 0),
+                    HomeCubeList(currenttabindex: 1),
+                    HomeCubeList(currenttabindex: 2),
+                    HomeCubeList(currenttabindex: 3),
+                  ],
+                ),
+              ),
             ),
           ],
         ),
@@ -78,8 +88,7 @@ class _HomeState extends State<Home> {
           Expanded(
             child: Container(
               color: AppColor.nicegrey,
-              child: HomeTabBar(
-                  initialindex: currenttabindex, callback: tabbarPressed),
+              child: HomeTabBar(controller: tabController),
             ),
           ),
           const SizedBox(
@@ -96,5 +105,12 @@ class _HomeState extends State<Home> {
         ],
       ),
     );
+  }
+
+  @override
+  void dispose() {
+    tabController.dispose();
+    homescrollcontroller.dispose();
+    super.dispose();
   }
 }

--- a/lib/widgets/home/hometabbar.dart
+++ b/lib/widgets/home/hometabbar.dart
@@ -7,10 +7,8 @@ import 'package:lottie/lottie.dart';
 import 'package:fr0gsite/l10n/app_localizations.dart';
 
 class HomeTabBar extends StatefulWidget {
-  const HomeTabBar(
-      {super.key, required this.callback, required this.initialindex});
-  final Function(int) callback;
-  final int initialindex;
+  const HomeTabBar({super.key, required this.controller});
+  final TabController controller;
   @override
   State<HomeTabBar> createState() => _HomeTabBarState();
 }
@@ -51,16 +49,12 @@ class _HomeTabBarState extends State<HomeTabBar> with TickerProviderStateMixin {
       showanimation = false;
     }
 
-    return DefaultTabController(
-      initialIndex: widget.initialindex,
-      length: 4,
-      child: TabBar(
+    return TabBar(
+          controller: widget.controller,
           onTap: (value) {
             setState(() {
               playAnimation();
             });
-
-            widget.callback(value);
           },
           dividerColor: Colors.transparent,
           unselectedLabelColor: Colors.grey[500],


### PR DESCRIPTION
## Summary
- overhaul `Home` to use `TabController` with a `TabBarView`
- update `HomeTabBar` to accept an external controller
- support horizontal swipe navigation across home tabs

## Testing
- `apt-get update`
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_687b5a6f2488832483834d2959cc551b