### PR TITLE
Localize Impressum strings

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -333,6 +333,8 @@
   "whitepaper": "الورقة البيضاء",
   "linktodocumentation": "الوثائق",
   "linktoupdown": "صفحة حالة updown.io",
+  "impressum": "البيانات القانونية",
+  "impressumloadfailed": "تعذر تحميل البيانات القانونية",
   "information": "معلومات",
   "links": "روابط",
   "rules": "القواعد",

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -333,6 +333,8 @@
   "whitepaper": "WhitePaper",
   "linktodocumentation": "Dokumentace",
   "linktoupdown": "Statusová stránka updown.io",
+  "impressum": "Tiráž",
+  "impressumloadfailed": "Nelze načíst tiráž",
   "information": "Informace",
   "links": "Odkazy",
   "rules": "Pravidla",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -333,6 +333,8 @@
   "whitepaper": "WhitePaper",
   "linktodocumentation": "Dokumentation",
   "linktoupdown": "updown.io Statusseite",
+  "impressum": "Impressum",
+  "impressumloadfailed": "Impressum konnte nicht geladen werden.",
   "information": "Informationen",
   "links": "Links",
   "rules": "Regeln",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -379,6 +379,8 @@
     "whitepaper": "WhitePaper",
     "linktodocumentation": "Documentation",
     "linktoupdown": "updown.io Status Page",
+    "impressum": "Legal notice",
+    "impressumloadfailed": "Could not load legal notice",
     "information": "Information",
     "links": "Links",
     "rules": "Rules",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -333,6 +333,8 @@
   "whitepaper": "WhitePaper",
   "linktodocumentation": "Documentación",
   "linktoupdown": "Página de estado de updown.io",
+  "impressum": "Aviso legal",
+  "impressumloadfailed": "No se pudo cargar el aviso legal",
   "information": "Información",
   "links": "Enlaces",
   "rules": "Reglas",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -333,6 +333,8 @@
   "whitepaper": "Livre blanc",
   "linktodocumentation": "Documentation",
   "linktoupdown": "Page d’état updown.io",
+  "impressum": "Mentions légales",
+  "impressumloadfailed": "Impossible de charger les mentions légales",
   "information": "Informations",
   "links": "Liens",
   "rules": "Règles",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -333,6 +333,8 @@
   "whitepaper": "श्वेतपत्र",
   "linktodocumentation": "प्रलेखन",
   "linktoupdown": "updown.io स्थिति पृष्ठ",
+  "impressum": "कानूनी सूचना",
+  "impressumloadfailed": "कानूनी सूचना लोड नहीं हो सकी",
   "information": "जानकारी",
   "links": "लिंक",
   "rules": "नियम",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -333,6 +333,8 @@
   "whitepaper": "WhitePaper",
   "linktodocumentation": "Documentazione",
   "linktoupdown": "Pagina di stato di updown.io",
+  "impressum": "Note legali",
+  "impressumloadfailed": "Impossibile caricare le note legali",
   "information": "Informazioni",
   "links": "Link",
   "rules": "Regole",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -333,6 +333,8 @@
   "whitepaper": "ホワイトペーパー",
   "linktodocumentation": "ドキュメンテーション",
   "linktoupdown": "updown.io ステータスページ",
+  "impressum": "インプリント",
+  "impressumloadfailed": "インプリントを読み込めませんでした",
   "information": "情報",
   "links": "リンク",
   "rules": "ルール",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -334,6 +334,8 @@
   "whitepaper": "백서",
   "linktodocumentation": "문서",
   "linktoupdown": "updown.io 상태 페이지",
+  "impressum": "법적 고지",
+  "impressumloadfailed": "법적 고지를 불러올 수 없습니다",
   "information": "정보",
   "links": "링크",
   "rules": "규칙",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2126,6 +2126,18 @@ abstract class AppLocalizations {
   /// **'updown.io Status Page'**
   String get linktoupdown;
 
+  /// No description provided for @impressum.
+  ///
+  /// In en, this message translates to:
+  /// **'Legal notice'**
+  String get impressum;
+
+  /// No description provided for @impressumloadfailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not load legal notice'**
+  String get impressumloadfailed;
+
   /// No description provided for @information.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -1048,6 +1048,12 @@ class AppLocalizationsAr extends AppLocalizations {
   String get linktoupdown => 'صفحة حالة updown.io';
 
   @override
+  String get impressum => 'البيانات القانونية';
+
+  @override
+  String get impressumloadfailed => 'تعذر تحميل البيانات القانونية';
+
+  @override
   String get information => 'معلومات';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1051,6 +1051,12 @@ class AppLocalizationsCs extends AppLocalizations {
   String get linktoupdown => 'Statusová stránka updown.io';
 
   @override
+  String get impressum => 'Tiráž';
+
+  @override
+  String get impressumloadfailed => 'Nelze načíst tiráž';
+
+  @override
   String get information => 'Informace';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1066,6 +1066,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get linktoupdown => 'updown.io Statusseite';
 
   @override
+  String get impressum => 'Impressum';
+
+  @override
+  String get impressumloadfailed => 'Impressum konnte nicht geladen werden.';
+
+  @override
   String get information => 'Informationen';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1056,6 +1056,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get linktoupdown => 'updown.io Status Page';
 
   @override
+  String get impressum => 'Legal notice';
+
+  @override
+  String get impressumloadfailed => 'Could not load legal notice';
+
+  @override
   String get information => 'Information';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1068,6 +1068,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get linktoupdown => 'Página de estado de updown.io';
 
   @override
+  String get impressum => 'Aviso legal';
+
+  @override
+  String get impressumloadfailed => 'No se pudo cargar el aviso legal';
+
+  @override
   String get information => 'Información';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1070,6 +1070,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get linktoupdown => 'Page d’état updown.io';
 
   @override
+  String get impressum => 'Mentions légales';
+
+  @override
+  String get impressumloadfailed => 'Impossible de charger les mentions légales';
+
+  @override
   String get information => 'Informations';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -1058,6 +1058,12 @@ class AppLocalizationsHi extends AppLocalizations {
   String get linktoupdown => 'updown.io स्थिति पृष्ठ';
 
   @override
+  String get impressum => 'कानूनी सूचना';
+
+  @override
+  String get impressumloadfailed => 'कानूनी सूचना लोड नहीं हो सकी';
+
+  @override
   String get information => 'जानकारी';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1069,6 +1069,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get linktoupdown => 'Pagina di stato di updown.io';
 
   @override
+  String get impressum => 'Note legali';
+
+  @override
+  String get impressumloadfailed => 'Impossibile caricare le note legali';
+
+  @override
   String get information => 'Informazioni';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1027,6 +1027,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get linktoupdown => 'updown.io ステータスページ';
 
   @override
+  String get impressum => 'インプリント';
+
+  @override
+  String get impressumloadfailed => 'インプリントを読み込めませんでした';
+
+  @override
   String get information => '情報';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -1024,6 +1024,12 @@ class AppLocalizationsKo extends AppLocalizations {
   String get linktoupdown => 'updown.io 상태 페이지';
 
   @override
+  String get impressum => '법적 고지';
+
+  @override
+  String get impressumloadfailed => '법적 고지를 불러올 수 없습니다';
+
+  @override
   String get information => '정보';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1067,6 +1067,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get linktoupdown => 'Página de status do updown.io';
 
   @override
+  String get impressum => 'Aviso legal';
+
+  @override
+  String get impressumloadfailed => 'Não foi possível carregar o aviso legal';
+
+  @override
   String get information => 'Informações';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1061,6 +1061,12 @@ class AppLocalizationsRu extends AppLocalizations {
   String get linktoupdown => 'Страница статуса updown.io';
 
   @override
+  String get impressum => 'Правовая информация';
+
+  @override
+  String get impressumloadfailed => 'Не удалось загрузить правовую информацию';
+
+  @override
   String get information => 'Информация';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -1063,6 +1063,12 @@ class AppLocalizationsUk extends AppLocalizations {
   String get linktoupdown => 'Сторінка статусу updown.io';
 
   @override
+  String get impressum => 'Правова інформація';
+
+  @override
+  String get impressumloadfailed => 'Не вдалося завантажити правову інформацію';
+
+  @override
   String get information => 'Інформація';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1019,6 +1019,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get linktoupdown => 'updown.io 状态页面';
 
   @override
+  String get impressum => '法律信息';
+
+  @override
+  String get impressumloadfailed => '无法加载法律信息';
+
+  @override
   String get information => '信息';
 
   @override

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -333,6 +333,8 @@
   "whitepaper": "WhitePaper",
   "linktodocumentation": "Documentação",
   "linktoupdown": "Página de status do updown.io",
+  "impressum": "Aviso legal",
+  "impressumloadfailed": "Não foi possível carregar o aviso legal",
   "information": "Informações",
   "links": "Links",
   "rules": "Regras",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -333,6 +333,8 @@
   "whitepaper": "WhitePaper",
   "linktodocumentation": "Документация",
   "linktoupdown": "Страница статуса updown.io",
+  "impressum": "Правовая информация",
+  "impressumloadfailed": "Не удалось загрузить правовую информацию",
   "information": "Информация",
   "links": "Ссылки",
   "rules": "Правила",

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -333,6 +333,8 @@
   "whitepaper": "WhitePaper",
   "linktodocumentation": "Документація",
   "linktoupdown": "Сторінка статусу updown.io",
+  "impressum": "Правова інформація",
+  "impressumloadfailed": "Не вдалося завантажити правову інформацію",
   "information": "Інформація",
   "links": "Посилання",
   "rules": "Правила",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -333,6 +333,8 @@
   "whitepaper": "白皮书",
   "linktodocumentation": "文档",
   "linktoupdown": "updown.io 状态页面",
+  "impressum": "法律信息",
+  "impressumloadfailed": "无法加载法律信息",
   "information": "信息",
   "links": "链接",
   "rules": "规则",

--- a/lib/widgets/infoscreens/impressum.dart
+++ b/lib/widgets/infoscreens/impressum.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 
 import '../../config.dart';
+import '../../l10n/app_localizations.dart';
 
 /// Popup dialog displaying the contents of the local `impressum.txt` file.
 class ImpressumView extends StatefulWidget {
@@ -28,7 +29,7 @@ class _ImpressumViewState extends State<ImpressumView> {
         _content =
             await rootBundle.loadString('assets/impressum.template.txt');
       } catch (_) {
-        _content = 'Impressum konnte nicht geladen werden.';
+        _content = AppLocalizations.of(context)!.impressumloadfailed;
       }
     }
     if (mounted) setState(() {});
@@ -67,7 +68,7 @@ class _ImpressumViewState extends State<ImpressumView> {
                     icon: const Icon(Icons.close, color: Colors.white),
                     onPressed: () => Navigator.pop(context),
                   ),
-                  title: const Text('Impressum'),
+                  title: Text(AppLocalizations.of(context)!.impressum),
                   centerTitle: true,
                 ),
                 body: _content.isEmpty

--- a/lib/widgets/infoscreens/informations.dart
+++ b/lib/widgets/infoscreens/informations.dart
@@ -112,7 +112,7 @@ class _InformationsState extends State<Informations> {
                       },
                     ),
                     SettingsTile(
-                      title: const Text('Impressum'),
+                      title: Text(AppLocalizations.of(context)!.impressum),
                       leading: const Icon(Icons.info_outline),
                       onPressed: (BuildContext context) {
                         showDialog(


### PR DESCRIPTION
## Summary
- add localized 'Impressum' and load failure messages across all languages
- expose new localization getters
- show localized Impressum label and error message in UI

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b68de8b88832483ac29f1678eaa79