### PR TITLE
Fix notifyListeners during build

### DIFF
--- a/lib/datatypes/postviewerstatus.dart
+++ b/lib/datatypes/postviewerstatus.dart
@@ -1,6 +1,7 @@
 import 'package:fr0gsite/datatypes/comment.dart';
 import 'package:fr0gsite/datatypes/upload.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 
 class PostviewerStatus extends ChangeNotifier {
   Upload currentupload = Upload.demo();
@@ -35,7 +36,12 @@ class PostviewerStatus extends ChangeNotifier {
   void setcurrentupload(Upload upload) {
     currentupload =
         uploadlist.firstWhere((element) => element.uploadid == upload.uploadid);
-    notifyListeners();
+    if (WidgetsBinding.instance.schedulerPhase == SchedulerPhase.persistentCallbacks ||
+        WidgetsBinding.instance.schedulerPhase == SchedulerPhase.transientCallbacks) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => notifyListeners());
+    } else {
+      notifyListeners();
+    }
   }
 
   Upload getcurrentupload() {


### PR DESCRIPTION
## Summary
- prevent `setcurrentupload` from firing `notifyListeners` during widget build

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d68e9db1c8324931cb4dee44ae5bf