### PR TITLE
Add web integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,20 @@ flutter build apk
 Feel free to translate parts of the application in your language.
 > The language files are here: **lib\l10n**
 
+### Running Web Integration Tests
+To execute the integration test in a browser you need Chrome or Chromium
+installed. Then run:
+
+```bash
+flutter drive \
+  --driver=test_driver/integration_test.dart \
+  --target=integration_test/web_app_test.dart \
+  -d chrome
+```
+
+This will launch the app in Chrome and perform basic interactions such as
+clicking the disclaimer button.
+
 If you find an bug you can report [here]()
 
 

--- a/integration_test/web_app_test.dart
+++ b/integration_test/web_app_test.dart
@@ -1,0 +1,23 @@
+import 'package:fr0gsite/main.dart' as app;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('web disclaimer test', (WidgetTester tester) async {
+    app.main();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Android'), findsWidgets);
+    expect(find.text('Apple'), findsWidgets);
+    expect(find.text('Windows'), findsWidgets);
+    expect(find.text('I agree'), findsWidgets);
+
+    await tester.tap(find.text('I agree'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('I agree'), findsNothing);
+  });
+}

--- a/test_driver/integration_test.dart
+++ b/test_driver/integration_test.dart
@@ -1,0 +1,3 @@
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() => integrationDriver();


### PR DESCRIPTION
## Summary
- add driver for integration_test
- add web integration test script
- document how to run integration tests in Chrome

## Testing
- `flutter test`
- `flutter test integration_test/app_test.dart -d chrome --timeout=60s` *(fails: Web devices are not supported for integration tests yet)*

------
https://chatgpt.com/codex/tasks/task_e_687d6d43dbdc8324be44bd22016d51de