### PR TITLE
Enable mouse wheel tab switching

### DIFF
--- a/lib/widgets/home/home.dart
+++ b/lib/widgets/home/home.dart
@@ -4,6 +4,7 @@ import 'package:fr0gsite/widgets/home/homecubelist.dart';
 import 'package:fr0gsite/widgets/home/hometabbar.dart';
 import 'package:fr0gsite/widgets/home/populartags.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/gestures.dart';
 import 'package:provider/provider.dart';
 
 const double headlinesize = 30;
@@ -23,6 +24,19 @@ class _HomeState extends State<Home> with TickerProviderStateMixin {
   int currenttabindex = 0;
   late TabController tabController;
   ScrollController homescrollcontroller = ScrollController();
+
+  void _handlePointerSignal(PointerSignalEvent event) {
+    if (event is PointerScrollEvent) {
+      final dx = event.scrollDelta.dx;
+      if (dx.abs() > event.scrollDelta.dy.abs()) {
+        if (dx > 0 && tabController.index > 0) {
+          tabController.animateTo(tabController.index - 1);
+        } else if (dx < 0 && tabController.index < tabController.length - 1) {
+          tabController.animateTo(tabController.index + 1);
+        }
+      }
+    }
+  }
 
   @override
   void initState() {
@@ -63,14 +77,17 @@ class _HomeState extends State<Home> with TickerProviderStateMixin {
               height: 1000,
               child: Container(
                 color: AppColor.nicegrey,
-                child: TabBarView(
-                  controller: tabController,
-                  children: const [
-                    HomeCubeList(currenttabindex: 0),
-                    HomeCubeList(currenttabindex: 1),
-                    HomeCubeList(currenttabindex: 2),
-                    HomeCubeList(currenttabindex: 3),
-                  ],
+                child: Listener(
+                  onPointerSignal: _handlePointerSignal,
+                  child: TabBarView(
+                    controller: tabController,
+                    children: const [
+                      HomeCubeList(currenttabindex: 0),
+                      HomeCubeList(currenttabindex: 1),
+                      HomeCubeList(currenttabindex: 2),
+                      HomeCubeList(currenttabindex: 3),
+                    ],
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
## Summary
- allow horizontal mouse wheel scroll to switch home tabs

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d725c3c508324ac9c167b93c71ccd