### PR TITLE
Add fullscreen toggle to post viewer

### DIFF
--- a/lib/datatypes/postviewerstatus.dart
+++ b/lib/datatypes/postviewerstatus.dart
@@ -12,6 +12,7 @@ class PostviewerStatus extends ChangeNotifier {
   double soundvolume = 0.0;
   List<Comment> commentlist = [];
   bool updatecommentbar = false;
+  bool fullscreen = false;
   
   bool _isPlaying = true;
   bool get isPlaying => _isPlaying;
@@ -110,6 +111,11 @@ class PostviewerStatus extends ChangeNotifier {
 
   List<Comment> getcommentlist() {
     return commentlist;
+  }
+
+  void togglefullscreen() {
+    fullscreen = !fullscreen;
+    notifyListeners();
   }
 
 

--- a/lib/widgets/postviewer/overlaywidgetbasic.dart
+++ b/lib/widgets/postviewer/overlaywidgetbasic.dart
@@ -148,6 +148,35 @@ Widget showTagsButton(function, int numoftags, context) {
   );
 }
 
+Widget fullscreenButton(context) {
+  return Consumer<PostviewerStatus>(
+    builder: (context, postviewerstatus, child) {
+      return GestureDetector(
+        onTap: () {
+          postviewerstatus.togglefullscreen();
+        },
+        child: Tooltip(
+          message:
+              postviewerstatus.fullscreen ? "Exit fullscreen" : "Fullscreen",
+          child: Container(
+            decoration: BoxDecoration(
+              color: AppColor.nicegrey.withAlpha((0.5 * 255).toInt()),
+              borderRadius: BorderRadius.circular(50),
+            ),
+            child: Icon(
+              postviewerstatus.fullscreen
+                  ? Icons.fullscreen_exit
+                  : Icons.fullscreen,
+              color: Colors.white.withAlpha((0.5 * 255).toInt()),
+              size: 40,
+            ),
+          ),
+        ),
+      );
+    },
+  );
+}
+
 Widget reportButton(context) {
   return GestureDetector(
       onTap: () {
@@ -250,30 +279,3 @@ Widget shareButton(context) {
   );
 }
 
-void fullscreen() {
-  debugPrint("fullscreen");
-}
-
-void comment() {
-  debugPrint("comment");
-}
-
-void upvote() {
-  debugPrint("upvote");
-}
-
-void downvote() {
-  debugPrint("downvote");
-}
-
-void tip() {
-  debugPrint("tip");
-}
-
-void report() {
-  debugPrint("report");
-}
-
-void share() {
-  debugPrint("share");
-}

--- a/lib/widgets/postviewer/postviewer.dart
+++ b/lib/widgets/postviewer/postviewer.dart
@@ -113,7 +113,16 @@ class PostviewerState extends State<Postviewer> {
                       flex: 2,
                       child: Column(
                         children: [
-                          const SizedBox(height: 60, child: PostViewerTopBar()),
+                          Consumer<PostviewerStatus>(
+                              builder: (context, postviewerstatus, child) {
+                            return AnimatedContainer(
+                              duration: const Duration(milliseconds: 300),
+                              height: postviewerstatus.fullscreen ? 0 : 60,
+                              child: postviewerstatus.fullscreen
+                                  ? null
+                                  : const PostViewerTopBar(),
+                            );
+                          }),
                           Expanded(
                               flex: 10,
                               child: Stack(
@@ -141,6 +150,10 @@ class PostviewerState extends State<Postviewer> {
                                       bottom: 10,
                                       right: 10,
                                       child: reportButton(context)),
+                                  Positioned(
+                                      bottom: 70,
+                                      right: 10,
+                                      child: fullscreenButton(context)),
                                   Positioned(
                                     right: 10,
                                     child: shareButton(context),
@@ -184,19 +197,35 @@ class PostviewerState extends State<Postviewer> {
                                   ),
                                 ],
                               )),
-                          Consumer<GlobalStatus>(
-                              builder: (context, userstatus, child) {
+                          Consumer<PostviewerStatus>(
+                              builder: (context, postviewerstatus, child) {
+                            return Consumer<GlobalStatus>(
+                                builder: (context, userstatus, child) {
+                              return AnimatedContainer(
+                                duration: const Duration(milliseconds: 300),
+                                height: postviewerstatus.fullscreen
+                                    ? 0
+                                    : (userstatus.expandedtagview ? 60 : 0),
+                                child: postviewerstatus.fullscreen
+                                    ? null
+                                    : userstatus.expandedtagview
+                                        ? const TagBarView()
+                                        : Container(
+                                            color: AppColor.niceblack,
+                                          ),
+                              );
+                            });
+                          }),
+                          Consumer<PostviewerStatus>(
+                              builder: (context, postviewerstatus, child) {
                             return AnimatedContainer(
                               duration: const Duration(milliseconds: 300),
-                              height: userstatus.expandedtagview ? 60 : 0,
-                              child: userstatus.expandedtagview
-                                  ? const TagBarView() : Container(
-                                      color: AppColor.niceblack,
-                                    ),
+                              height: postviewerstatus.fullscreen ? 0 : 60,
+                              child: postviewerstatus.fullscreen
+                                  ? null
+                                  : const PostViewerBottomBar(),
                             );
                           }),
-                          const SizedBox(
-                              height: 60, child: PostViewerBottomBar()),
                         ],
                       ),
                     ),


### PR DESCRIPTION
## Summary
- add fullscreen state to PostviewerStatus
- add fullscreen toggle button overlay above report button
- hide top/tag/bottom bars when fullscreen is active

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a97eef1a2483248ed50f03a3c56117