### PR TITLE
Fix Postviewer back navigation on web

### DIFF
--- a/lib/widgets/backbutton.dart
+++ b/lib/widgets/backbutton.dart
@@ -1,5 +1,7 @@
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:fr0gsite/config.dart';
+import 'package:universal_html/html.dart' as html;
 
 Widget backButton(context) {
     return Padding(
@@ -17,9 +19,12 @@ Widget backButton(context) {
             size: 25,
           ),
           onPressed: () {
-            if (Navigator.canPop(context)) {
-              //Provider.of<PostviewerStatus>(context, listen: false).pause();
+            final bool canPop = Navigator.canPop(context);
+            final bool hasHistory = !kIsWeb || html.window.history.length > 1;
+            if (canPop && hasHistory) {
               Navigator.pop(context);
+            } else {
+              Navigator.pushReplacementNamed(context, '/home');
             }
           },
         ),

--- a/lib/widgets/postviewer/postviewertopbar.dart
+++ b/lib/widgets/postviewer/postviewertopbar.dart
@@ -1,10 +1,12 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:fr0gsite/config.dart';
 import 'package:fr0gsite/datatypes/postviewerstatus.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:fr0gsite/widgets/postviewer/subscriptionicon.dart';
 import 'package:fr0gsite/widgets/topbar/topbar.dart';
 import 'package:provider/provider.dart';
+import 'package:universal_html/html.dart' as html;
 
 import '../resources/resourceviewertopbar.dart';
 
@@ -45,7 +47,9 @@ class _PostViewerTopBarState extends State<PostViewerTopBar> {
                         size: 25,
                       ),
                       onPressed: () {
-                        if (Navigator.canPop(context)) {
+                        final bool canPop = Navigator.canPop(context);
+                        final bool hasHistory = !kIsWeb || html.window.history.length > 1;
+                        if (canPop && hasHistory) {
                           Navigator.pop(context);
                         } else {
                           Navigator.pushReplacementNamed(context, '/home');


### PR DESCRIPTION
## Summary
- ensure Postviewer back button redirects to home when browser history is empty
- update shared backButton widget to check browser history before popping

## Testing
- `dart format lib/widgets/backbutton.dart lib/widgets/postviewer/postviewertopbar.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0cf18cec8324ae9b3e8b39e84b30