### PR TITLE
Rename Classic grid view to List

### DIFF
--- a/lib/datatypes/gridstatus.dart
+++ b/lib/datatypes/gridstatus.dart
@@ -5,7 +5,7 @@ class GridStatus extends ChangeNotifier {
   bool showpicture = true;
   bool showvideo = true;
   bool showinfowithouthover = true;
-  bool showclassic = false;
+  bool showlist = false;
 
   bool filterstatus = false;
   double filterminvalue = 0;
@@ -45,14 +45,14 @@ class GridStatus extends ChangeNotifier {
     notifyListeners();
   }
 
-  void setshowclassic(bool value) {
-    showclassic = value;
+  void setshowlist(bool value) {
+    showlist = value;
     notifyListeners();
   }
 
-  void toggleclassic() {
-    showclassic = !showclassic;
-    debugPrint("GridStatus: toggleclassic: $showclassic");
+  void togglelist() {
+    showlist = !showlist;
+    debugPrint("GridStatus: togglelist: $showlist");
     notifyListeners();
   }
 

--- a/lib/widgets/cube/listitem.dart
+++ b/lib/widgets/cube/listitem.dart
@@ -12,16 +12,16 @@ import 'package:fr0gsite/ipfsactions.dart';
 import 'package:fr0gsite/widgets/login/login.dart';
 import 'package:provider/provider.dart';
 
-class ClassicItem extends StatefulWidget {
-  const ClassicItem({super.key, required this.upload});
+class ListItem extends StatefulWidget {
+  const ListItem({super.key, required this.upload});
 
   final Upload upload;
 
   @override
-  State<ClassicItem> createState() => _ClassicItemState();
+  State<ListItem> createState() => _ListItemState();
 }
 
-class _ClassicItemState extends State<ClassicItem> {
+class _ListItemState extends State<ListItem> {
   late Future _imageFuture;
   Uint8List _imageBytes = Uint8List.fromList([]);
 

--- a/lib/widgets/grid/creategrid.dart
+++ b/lib/widgets/grid/creategrid.dart
@@ -2,7 +2,7 @@ import 'package:fr0gsite/config.dart';
 import 'package:fr0gsite/datatypes/globalstatus.dart';
 import 'package:fr0gsite/datatypes/upload.dart';
 import 'package:fr0gsite/widgets/cube/cube.dart';
-import 'package:fr0gsite/widgets/cube/classicitem.dart';
+import 'package:fr0gsite/widgets/cube/listitem.dart';
 import 'package:fr0gsite/datatypes/gridstatus.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -21,16 +21,16 @@ class CreateGrid extends StatefulWidget {
 class _CreateGridState extends State<CreateGrid> {
   List<Widget> items = [];
   int minRow = 1;
-  bool lastclassic = false;
+  bool lastlist = false;
   final ScrollController _scrollController = ScrollController();
 
   @override
   void initState() {
     super.initState();
-    lastclassic = Provider.of<GridStatus>(context, listen: false).showclassic;
+    lastlist = Provider.of<GridStatus>(context, listen: false).showlist;
     for (var upload in widget.uploadlist) {
-      items.add(lastclassic
-          ? ClassicItem(
+      items.add(lastlist
+          ? ListItem(
               upload: upload,
             )
           : Cube(
@@ -76,14 +76,14 @@ class _CreateGridState extends State<CreateGrid> {
 
   @override
   Widget build(BuildContext context) {
-    bool showclassic = Provider.of<GridStatus>(context, listen: true).showclassic;
+    bool showlist = Provider.of<GridStatus>(context, listen: true).showlist;
     checkforupdates();
-    if (!showclassic) {
+    if (!showlist) {
       checkGridRows();
     }
     return Padding(
       padding: const EdgeInsets.all(8.0),
-      child: showclassic ? getlistview() : getgridview(),
+      child: showlist ? getlistview() : getgridview(),
     );
   }
 
@@ -94,14 +94,14 @@ class _CreateGridState extends State<CreateGrid> {
   }
 
   void checkforupdates() {
-    bool showclassic = Provider.of<GridStatus>(context, listen: false).showclassic;
-    if (items.length != widget.uploadlist.length || showclassic != lastclassic) {
+    bool showlist = Provider.of<GridStatus>(context, listen: false).showlist;
+    if (items.length != widget.uploadlist.length || showlist != lastlist) {
       setState(() {
-        lastclassic = showclassic;
+        lastlist = showlist;
         items = [];
         for (var upload in widget.uploadlist) {
-          items.add(showclassic
-              ? ClassicItem(
+          items.add(showlist
+              ? ListItem(
                   upload: upload,
                 )
               : Cube(

--- a/lib/widgets/grid/gridfilderbutton.dart
+++ b/lib/widgets/grid/gridfilderbutton.dart
@@ -54,11 +54,11 @@ class _GridFilterButtonState extends State<GridFilterButton> {
           ),
           _buildFilterButton(
             context,
-            label: 'Classic',
+            label: 'List',
             icon: Icons.view_list,
-            isActive: Provider.of<GridStatus>(context, listen: true).showclassic,
+            isActive: Provider.of<GridStatus>(context, listen: true).showlist,
             onPressed: () {
-              Provider.of<GridStatus>(context, listen: false).toggleclassic();
+              Provider.of<GridStatus>(context, listen: false).togglelist();
             },
           ),
           _buildFilterButton(
@@ -103,8 +103,8 @@ class _GridFilterButtonState extends State<GridFilterButton> {
                 Provider.of<GridStatus>(context, listen: false).togglevideo();
                 widget.uploadorder.showvideos(Provider.of<GridStatus>(context, listen: false).showvideo);
                 break;
-              case "classic":
-                Provider.of<GridStatus>(context, listen: false).toggleclassic();
+              case "list":
+                Provider.of<GridStatus>(context, listen: false).togglelist();
                 break;
               case "info":
                 Provider.of<GridStatus>(context, listen: false).toggleinfowithouthover();
@@ -119,7 +119,7 @@ class _GridFilterButtonState extends State<GridFilterButton> {
           itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
             _buildMenuItem("pictures", AppLocalizations.of(context)!.pictures, Icons.photo_size_select_actual_rounded, Provider.of<GridStatus>(context, listen: false).showpicture),
             _buildMenuItem("videos", AppLocalizations.of(context)!.videos, Icons.video_camera_back_sharp, Provider.of<GridStatus>(context, listen: false).showvideo),
-            _buildMenuItem("classic", 'Classic', Icons.view_list, Provider.of<GridStatus>(context, listen: false).showclassic),
+            _buildMenuItem("list", 'List', Icons.view_list, Provider.of<GridStatus>(context, listen: false).showlist),
             _buildMenuItem("info", AppLocalizations.of(context)!.info, Icons.info_sharp, Provider.of<GridStatus>(context, listen: false).showinfowithouthover),
             _buildMenuItem("filter", AppLocalizations.of(context)!.filter, Icons.sort,  true),
           ],


### PR DESCRIPTION
## Summary
- rename ClassicItem widget and Classic view to ListItem and list view
- update grid filtering buttons and state management to use List terminology

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0d469658832483f4226b32aa7571