### PR TITLE
Enable horizontal swipe between favorites tabs

### DIFF
--- a/lib/widgets/favorite/favorite.dart
+++ b/lib/widgets/favorite/favorite.dart
@@ -5,6 +5,7 @@ import 'package:fr0gsite/widgets/favorite/favoritetagsview.dart';
 import 'package:fr0gsite/widgets/favorite/favoriteuploadview.dart';
 import 'package:fr0gsite/widgets/infoscreens/pleaselogin.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/gestures.dart';
 import 'package:fr0gsite/l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 
@@ -65,8 +66,11 @@ class _FavoriteState extends State<Favorite> {
             Expanded(child: Consumer<GlobalStatus>(
               builder: (context, userstatus, child) {
                 if (userstatus.isLoggedin) {
-                  return TabBarView(
-                    children: tabBarViews,
+                  return ScrollConfiguration(
+                    behavior: AppScrollBehavior(),
+                    child: TabBarView(
+                      children: tabBarViews,
+                    ),
                   );
                 } else {
                   return Padding(
@@ -95,4 +99,12 @@ class _FavoriteState extends State<Favorite> {
       ),
     );
   }
+}
+
+class AppScrollBehavior extends MaterialScrollBehavior {
+  @override
+  Set<PointerDeviceKind> get dragDevices => {
+        PointerDeviceKind.touch,
+        PointerDeviceKind.mouse,
+      };
 }


### PR DESCRIPTION
## Summary
- allow swiping between favorites tabs by wrapping TabBarView with a custom scroll configuration
- add `AppScrollBehavior` to support touch and mouse drags

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b58d68b36c83249e70e5d7388d1201