### PR TITLE
Enable swipe navigation on wallet tabs

### DIFF
--- a/lib/widgets/wallet/wallet.dart
+++ b/lib/widgets/wallet/wallet.dart
@@ -16,15 +16,24 @@ class Wallet extends StatefulWidget {
   State<Wallet> createState() => _WalletState();
 }
 
-class _WalletState extends State<Wallet> {
-  List<Widget> tabBarViews = [
-    const WalletSend(),
-    const Walletreceive(),
+class _WalletState extends State<Wallet> with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  final List<Widget> tabBarViews = const [
+    WalletSend(),
+    Walletreceive(),
   ];
 
   @override
   void initState() {
     super.initState();
+    _tabController = TabController(length: tabBarViews.length, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
   }
 
   @override
@@ -45,45 +54,58 @@ class _WalletState extends State<Wallet> {
       color: AppColor.nicegrey,
       child: Consumer<GlobalStatus>(
         builder: (context, userstatus, child) {
-          return DefaultTabController(
-            length: 2,
-            child: Column(
-              children: [
-                TabBar(
-                  indicatorColor: Colors.transparent,
-                  unselectedLabelColor: Colors.grey[500],
-                  labelColor: Colors.white,
-                  dividerColor: Colors.transparent,
-                  indicator: gloabltabindicator,
-                  indicatorSize: TabBarIndicatorSize.tab,
-                  tabs: tabs,
-                ),
-                Expanded(
-                  child: userstatus.isLoggedin
-                      ? TabBarView(
+          return Column(
+            children: [
+              TabBar(
+                controller: _tabController,
+                indicatorColor: Colors.transparent,
+                unselectedLabelColor: Colors.grey[500],
+                labelColor: Colors.white,
+                dividerColor: Colors.transparent,
+                indicator: gloabltabindicator,
+                indicatorSize: TabBarIndicatorSize.tab,
+                tabs: tabs,
+              ),
+              Expanded(
+                child: userstatus.isLoggedin
+                    ? GestureDetector(
+                        behavior: HitTestBehavior.translucent,
+                        onHorizontalDragEnd: (details) {
+                          if (details.primaryVelocity == null) return;
+                          if (details.primaryVelocity! < 0 &&
+                              _tabController.index < _tabController.length - 1) {
+                            _tabController.animateTo(_tabController.index + 1);
+                          } else if (details.primaryVelocity! > 0 &&
+                              _tabController.index > 0) {
+                            _tabController.animateTo(_tabController.index - 1);
+                          }
+                        },
+                        child: TabBarView(
+                          controller: _tabController,
+                          physics: const NeverScrollableScrollPhysics(),
                           children: tabBarViews,
-                        )
-                      : Padding(
-                          padding: const EdgeInsets.all(16.0),
-                          child: SingleChildScrollView(
-                            child: Wrap(
-                              alignment: WrapAlignment.center,
-                              spacing: 50,
-                              runSpacing: 50,
-                              children: [
-                                Container(
-                                    decoration: BoxDecoration(
-                                        color: AppColor.niceblack,
-                                        borderRadius: BorderRadius.circular(10),
-                                        border: Border.all(color: Colors.grey)),
-                                    child: const Pleaselogin()),
-                              ],
-                            ),
+                        ),
+                      )
+                    : Padding(
+                        padding: const EdgeInsets.all(16.0),
+                        child: SingleChildScrollView(
+                          child: Wrap(
+                            alignment: WrapAlignment.center,
+                            spacing: 50,
+                            runSpacing: 50,
+                            children: [
+                              Container(
+                                  decoration: BoxDecoration(
+                                      color: AppColor.niceblack,
+                                      borderRadius: BorderRadius.circular(10),
+                                      border: Border.all(color: Colors.grey)),
+                                  child: const Pleaselogin()),
+                            ],
                           ),
                         ),
-                ),
-              ],
-            ),
+                      ),
+              ),
+            ],
           );
         },
       ),


### PR DESCRIPTION
## Summary
- Allow users to change between Send and Receive wallet tabs via horizontal swipe gestures

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b58d85a4508324909e3d8861320bfb