### PR TITLE
feat(wallet): allow sending arbitrary tokens

### DIFF
--- a/lib/chainactions/actionlist.dart
+++ b/lib/chainactions/actionlist.dart
@@ -163,10 +163,10 @@ List<Action> newaccount(String creator, String newusername, String ownerpubkey,
 }
 
 List<Action> sendtokenlistaction(
-    String from, String to, String amount, String memo, auth) {
+    String contract, String from, String to, String amount, String memo, auth) {
   List<Action> actions = [
     Action()
-      ..account = AppConfig.blockchainsystemtokencontract
+      ..account = contract
       ..data = {"from": from, "to": to, "quantity": amount, "memo": memo}
       ..name = "transfer"
       ..authorization = auth,

--- a/lib/chainactions/chainactions.dart
+++ b/lib/chainactions/chainactions.dart
@@ -564,10 +564,10 @@ class Chainactions {
   }
 
   Future<bool> sendtoken(
-      String from, String to, String amount, String memo) async {
+      String contract, String from, String to, String amount, String memo) async {
     actionsbeforetransaction();
     List<Action> actions =
-        sendtokenlistaction(from, to, amount, memo, getauth());
+        sendtokenlistaction(contract, from, to, amount, memo, getauth());
     return transactionHandler(actions);
   }
 

--- a/lib/datatypes/usertoken.dart
+++ b/lib/datatypes/usertoken.dart
@@ -1,0 +1,11 @@
+class UserToken {
+  final String symbol;
+  final String contract;
+  final int decimals;
+
+  const UserToken({
+    required this.symbol,
+    required this.contract,
+    required this.decimals,
+  });
+}

--- a/lib/datatypes/walletstatus.dart
+++ b/lib/datatypes/walletstatus.dart
@@ -1,5 +1,6 @@
 import 'package:eosdart/eosdart.dart';
 import 'package:flutter/material.dart';
+import 'package:fr0gsite/config.dart';
 
 class WalletStatus extends ChangeNotifier {
   String sendtoaccountname = "";
@@ -7,4 +8,7 @@ class WalletStatus extends ChangeNotifier {
   String amount = "";
   int balance = 0;
   String memo = ""; // Max 256 characters
+  String tokenselected = AppConfig.systemtoken;
+  String tokencontract = AppConfig.blockchainsystemtokencontract;
+  int tokendecimalafterdot = AppConfig.systemtokendecimalafterdot;
 }

--- a/lib/widgets/wallet/walletconfirmtransaction.dart
+++ b/lib/widgets/wallet/walletconfirmtransaction.dart
@@ -16,11 +16,17 @@ class WalletConfirmTransaction extends StatefulWidget {
       required this.callback,
       required this.sendtoaccount,
       required this.amount,
-      required this.memo});
+      required this.memo,
+      required this.token,
+      required this.contract,
+      required this.tokendecimals});
   final Function callback;
   final String sendtoaccount;
   final String amount;
   final String memo;
+  final String token;
+  final String contract;
+  final int tokendecimals;
 
   @override
   State<WalletConfirmTransaction> createState() =>
@@ -53,7 +59,7 @@ class _WalletConfirmTransactionState extends State<WalletConfirmTransaction> {
                 Padding(
                   padding: const EdgeInsets.all(8.0),
                   child: AutoSizeText(
-                    "${widget.amount} ${AppConfig.systemtoken} -> ${widget.sendtoaccount}",
+                    "${widget.amount} ${widget.token} -> ${widget.sendtoaccount}",
                     style: const TextStyle(
                       color: Colors.white,
                     ),
@@ -85,7 +91,7 @@ class _WalletConfirmTransactionState extends State<WalletConfirmTransaction> {
                       double parsedamount = double.parse(widget.amount);
 
                       String amountinformat =
-                          "${parsedamount.toStringAsFixed(AppConfig.systemtokendecimalafterdot)} ${AppConfig.systemtoken}";
+                          "${parsedamount.toStringAsFixed(widget.tokendecimals)} ${widget.token}";
 
                       Chainactions()
                         ..setusernameandpermission(
@@ -94,6 +100,7 @@ class _WalletConfirmTransactionState extends State<WalletConfirmTransaction> {
                             Provider.of<GlobalStatus>(context, listen: false)
                                 .permission)
                         ..sendtoken(
+                                widget.contract,
                                 Provider.of<GlobalStatus>(context,
                                         listen: false)
                                     .username,


### PR DESCRIPTION
## Summary
- allow specifying token contract in transfer actions
- track selected token in wallet state
- populate wallet send form with user tokens and dropdown selection

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b58e8c58cc832492e82fe84dc3690a