### PR TITLE
Enable global light/dark theme toggle

### DIFF
--- a/lib/config.dart
+++ b/lib/config.dart
@@ -6,13 +6,27 @@ import 'package:fr0gsite/datatypes/rewardtoken.dart';
 import 'package:fr0gsite/datatypes/blockchainnode.dart';
 import 'package:flutter/material.dart';
 
+/// Collection of application wide colors.
+///
+/// The colors change depending on whether the app runs in dark or light mode.
+/// Call [updateTheme] whenever the theme changes so widgets using these colors
+/// automatically switch their appearance.
 class AppColor {
-  static const Color nicewhite = Color.fromARGB(255, 230, 230, 230);
-  //static const Color niceblack = Color(0xFF060716);
-  static const Color niceblack = Color(0xFF060716);
-  //static const Color nicegrey = Color(0xFF161722);
-  static const Color nicegrey = Color(0xFF161722);
-  static const Color textcolor = Color(0xFFFFFFFF);
+  static bool _isDarkMode = true;
+
+  static void updateTheme(bool isDark) {
+    _isDarkMode = isDark;
+  }
+
+  static Color get nicewhite =>
+      _isDarkMode ? const Color.fromARGB(255, 230, 230, 230) : Colors.black;
+  static Color get niceblack =>
+      _isDarkMode ? const Color(0xFF060716) : Colors.white;
+  static Color get nicegrey =>
+      _isDarkMode ? const Color(0xFF161722) : const Color(0xFFE0E0E0);
+  static Color get textcolor =>
+      _isDarkMode ? const Color(0xFFFFFFFF) : Colors.black;
+
   static Color tagcolor = Colors.blue;
   static Color uploadcolor = Colors.green;
   static Color commentcolor = Colors.red;
@@ -61,12 +75,17 @@ class Ressourcecolor {
   static const Color act = Colors.green;
 }
 
-const defauldtextstyle = TextStyle(color: AppColor.textcolor, fontSize: 20);
-const textstyleTitle = TextStyle(color: AppColor.textcolor, fontSize: 30);
-const textstyleNormal = TextStyle(color: AppColor.textcolor, fontSize: 20);
-const textstyleSmall = TextStyle(color: AppColor.textcolor, fontSize: 10);
+TextStyle get defauldtextstyle =>
+    TextStyle(color: AppColor.textcolor, fontSize: 20);
+TextStyle get textstyleTitle =>
+    TextStyle(color: AppColor.textcolor, fontSize: 30);
+TextStyle get textstyleNormal =>
+    TextStyle(color: AppColor.textcolor, fontSize: 20);
+TextStyle get textstyleSmall =>
+    TextStyle(color: AppColor.textcolor, fontSize: 10);
 
-const cubetextstyle = TextStyle(color: AppColor.textcolor, fontSize: 15);
+TextStyle get cubetextstyle =>
+    TextStyle(color: AppColor.textcolor, fontSize: 15);
 
 //Postviwer
 const iconsize = 55.0;

--- a/lib/datatypes/themestatus.dart
+++ b/lib/datatypes/themestatus.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../config.dart';
+
+/// Manages the current [ThemeMode] of the application.
+///
+/// The value is persisted using [SharedPreferences] so the chosen theme
+/// survives app restarts.
+class ThemeStatus extends ChangeNotifier {
+  static const _storageKey = 'isDarkMode';
+
+  ThemeMode _themeMode = ThemeMode.dark;
+
+  ThemeStatus() {
+    _loadTheme();
+  }
+
+  ThemeMode get themeMode => _themeMode;
+  bool get isDarkMode => _themeMode == ThemeMode.dark;
+
+  void toggleTheme(bool isDark) {
+    _themeMode = isDark ? ThemeMode.dark : ThemeMode.light;
+    AppColor.updateTheme(isDark);
+    _saveTheme(isDark);
+    notifyListeners();
+  }
+
+  Future<void> _loadTheme() async {
+    final prefs = await SharedPreferences.getInstance();
+    final isDark = prefs.getBool(_storageKey) ?? true;
+    _themeMode = isDark ? ThemeMode.dark : ThemeMode.light;
+    AppColor.updateTheme(isDark);
+    notifyListeners();
+  }
+
+  Future<void> _saveTheme(bool isDark) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_storageKey, isDark);
+  }
+}
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,7 @@ import 'package:url_strategy/url_strategy.dart';
 
 import 'config.dart';
 import 'datatypes/postviewerstatus.dart';
+import 'datatypes/themestatus.dart';
 import 'l10n/l10n.dart';
 import 'widgets/favorite/favorite.dart';
 import 'widgets/follow/follow.dart';
@@ -55,6 +56,8 @@ void main() {
             create: (context) => TrusterStatus()),
         ChangeNotifierProvider<BlacklistStatus>(
             create: (context) => BlacklistStatus()),
+        ChangeNotifierProvider<ThemeStatus>(
+            create: (context) => ThemeStatus()),
       ],
       builder: (context, child) {
         return const App();
@@ -80,14 +83,39 @@ class _MyAppState extends State<App> {
 
   @override
   Widget build(BuildContext context) {
+    final themeStatus = Provider.of<ThemeStatus>(context);
     return MaterialApp(
         title: 'Fr0gsite',
         debugShowCheckedModeBanner: false,
+        themeMode: themeStatus.themeMode,
         theme: ThemeData(
           brightness: Brightness.light,
           primarySwatch: Colors.blue,
-          scaffoldBackgroundColor: AppColor.niceblack,
+          scaffoldBackgroundColor: Colors.white,
           appBarTheme: const AppBarTheme(
+            backgroundColor: Colors.white,
+            foregroundColor: Colors.black,
+            elevation: 0,
+            centerTitle: true,
+          ),
+          useMaterial3: true,
+          visualDensity: VisualDensity.adaptivePlatformDensity,
+          textSelectionTheme: const TextSelectionThemeData(
+            selectionColor: Colors.blue,
+          ),
+          scrollbarTheme: ScrollbarThemeData(
+            thumbColor: WidgetStateProperty.all(Colors.black),
+          ),
+          textTheme: GoogleFonts.mitrTextTheme().apply(
+            bodyColor: Colors.black,
+            displayColor: Colors.black,
+          ),
+        ),
+        darkTheme: ThemeData(
+          brightness: Brightness.dark,
+          primarySwatch: Colors.blue,
+          scaffoldBackgroundColor: AppColor.niceblack,
+          appBarTheme: AppBarTheme(
             backgroundColor: AppColor.niceblack,
             foregroundColor: Colors.white,
             elevation: 0,

--- a/lib/widgets/infoscreens/informations.dart
+++ b/lib/widgets/infoscreens/informations.dart
@@ -58,18 +58,18 @@ class _InformationsState extends State<Informations> {
               platform: DevicePlatform.web,
               lightTheme: SettingsThemeData(
                 settingsListBackground: AppColor.nicegrey,
-                titleTextColor: Colors.white,
+                titleTextColor: AppColor.textcolor,
                 settingsSectionBackground:
-                    Colors.white.withAlpha((0.8 * 255).toInt()),
+                    AppColor.niceblack.withAlpha((0.8 * 255).toInt()),
               ),
               darkTheme:
-                  const SettingsThemeData(settingsListBackground: AppColor.nicegrey),
+                  SettingsThemeData(settingsListBackground: AppColor.nicegrey),
               sections: [
                 SettingsSection(
                   title: Text(
                     AppLocalizations.of(context)!.links,
-                    style: const TextStyle(
-                        color: Colors.white,
+                    style: TextStyle(
+                        color: AppColor.textcolor,
                         fontSize: 20,
                         fontWeight: FontWeight.w500),
                   ),
@@ -126,8 +126,8 @@ class _InformationsState extends State<Informations> {
                 SettingsSection(
                   title: Text(
                     AppLocalizations.of(context)!.rulesandguidelines,
-                    style: const TextStyle(
-                        color: Colors.white,
+                    style: TextStyle(
+                        color: AppColor.textcolor,
                         fontSize: 20,
                         fontWeight: FontWeight.w500),
                   ),

--- a/lib/widgets/profile/profile.dart
+++ b/lib/widgets/profile/profile.dart
@@ -116,7 +116,7 @@ class _ProfileState extends State<Profile> {
               children: [
                 profiletopbar(),
                 Divider(
-                  color: Colors.white.withAlpha((0.5 * 255).toInt()),
+                  color: AppColor.nicewhite.withAlpha((0.5 * 255).toInt()),
                   height: 2,
                 ),
                 AnimatedContainer(
@@ -157,7 +157,7 @@ class _ProfileState extends State<Profile> {
 
   Widget profiletopbar() {
     return Container(
-      decoration: const BoxDecoration(
+      decoration: BoxDecoration(
         color: AppColor.niceblack,
       ),
       child: Row(
@@ -166,13 +166,13 @@ class _ProfileState extends State<Profile> {
             width: 50,
             child: IconButton(
               icon: const Icon(Icons.backspace_rounded),
-              color: Colors.white,
+              color: AppColor.nicewhite,
               onPressed: () {
-                if(Navigator.canPop(context)){
+                if (Navigator.canPop(context)) {
                   Navigator.pop(context);
-                }else{
+                } else {
                   Navigator.pushNamed(context, "/");
-                }                
+                }
               },
             ),
           ),

--- a/lib/widgets/profile/useruploadsview.dart
+++ b/lib/widgets/profile/useruploadsview.dart
@@ -68,8 +68,9 @@ class _UserUploadViewState extends State<UserUploadView> {
                       return Column(
                         children: [
                           Center(
-                            child: Text(AppLocalizations.of(context)!.nouploadsfound,
-                                style: const TextStyle(color: AppColor.nicewhite)),
+                            child: Text(
+                                AppLocalizations.of(context)!.nouploadsfound,
+                                style: TextStyle(color: AppColor.nicewhite)),
                           ),
                         ],
                       );
@@ -79,9 +80,9 @@ class _UserUploadViewState extends State<UserUploadView> {
                       loadmorecallback: loadmorecallback,
                     );
                   } else {
-                    return const Center(
+                    return Center(
                       child: CircularProgressIndicator(
-                        color: Colors.white,
+                        color: AppColor.textcolor,
                         strokeWidth: 15,
                       ),
                     );

--- a/lib/widgets/resources/accountbalance.dart
+++ b/lib/widgets/resources/accountbalance.dart
@@ -179,7 +179,7 @@ class _AccountBalanceState extends State<AccountBalance> {
                 ],
               ),
               TableRow(
-                decoration: const BoxDecoration(color: AppColor.niceblack),
+                decoration: BoxDecoration(color: AppColor.niceblack),
                 children: [
                   TableCell(
                     child: Tooltip(

--- a/lib/widgets/resources/stakeorunstake.dart
+++ b/lib/widgets/resources/stakeorunstake.dart
@@ -176,7 +176,7 @@ class _StakeorUnstakeState extends State<StakeorUnstake> {
                   border: TableBorder.all(color: Colors.grey),
                   children: [
                     TableRow(
-                        decoration: const BoxDecoration(
+                        decoration: BoxDecoration(
                           color: AppColor.nicegrey,
                         ),
                         children: [
@@ -184,10 +184,10 @@ class _StakeorUnstakeState extends State<StakeorUnstake> {
                             padding: const EdgeInsets.all(8.0),
                             child: Text(
                               AppLocalizations.of(context)!.resources,
-                              style: const TextStyle(
+                              style: TextStyle(
                                   fontSize: 15,
                                   fontWeight: FontWeight.bold,
-                                  color: Colors.white),
+                                  color: AppColor.textcolor),
                             ),
                           ),
                           const Padding(

--- a/lib/widgets/settings/settings.dart
+++ b/lib/widgets/settings/settings.dart
@@ -6,6 +6,7 @@ import 'package:fr0gsite/widgets/settings/setlanguageview.dart';
 import 'package:fr0gsite/widgets/infoscreens/impressum.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:fr0gsite/datatypes/themestatus.dart';
 import 'package:settings_ui/settings_ui.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:fr0gsite/l10n/app_localizations.dart';
@@ -20,10 +21,11 @@ class Settings extends StatelessWidget {
         platform: DevicePlatform.web,
         lightTheme: SettingsThemeData(
             settingsListBackground: AppColor.nicegrey,
-            titleTextColor: Colors.white,
-            settingsSectionBackground: Colors.white.withAlpha((0.8 * 255).toInt())),
+            titleTextColor: AppColor.textcolor,
+            settingsSectionBackground:
+                AppColor.niceblack.withAlpha((0.8 * 255).toInt())),
         darkTheme:
-            const SettingsThemeData(settingsListBackground: AppColor.nicegrey),
+            SettingsThemeData(settingsListBackground: AppColor.nicegrey),
         sections: [
           SettingsSection(
             title: Text(AppLocalizations.of(context)!.settingcommon),
@@ -201,23 +203,16 @@ class Settings extends StatelessWidget {
                       builder: (_) => const SetLanguageView());
                 },
               ),
-              SettingsTile(
+              SettingsTile.switchTile(
                 title: Text(AppLocalizations.of(context)!.theme),
                 description: Text(AppLocalizations.of(context)!.lightordark),
                 leading: const Icon(Icons.format_paint),
-                onPressed: (BuildContext context) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: Center(
-                          child: Text(
-                        AppLocalizations.of(context)!
-                            .thisfeatureisnotavailableyet,
-                        style: const TextStyle(fontSize: 30),
-                      )),
-                      duration: const Duration(seconds: 1),
-                    ),
-                  );
+                onToggle: (value) {
+                  Provider.of<ThemeStatus>(context, listen: false)
+                      .toggleTheme(value);
                 },
+                initialValue:
+                    Provider.of<ThemeStatus>(context, listen: true).isDarkMode,
               )
             ],
           ),


### PR DESCRIPTION
## Summary
- add `ThemeStatus` provider with persistence for theme mode
- wire MaterialApp to ThemeStatus and provide light/dark ThemeData
- expose a theme switch in settings and adapt app colors

## Testing
- `flutter format lib/config.dart lib/datatypes/themestatus.dart lib/main.dart lib/widgets/settings/settings.dart lib/widgets/infoscreens/informations.dart lib/widgets/profile/useruploadsview.dart lib/widgets/resources/accountbalance.dart lib/widgets/resources/stakeorunstake.dart lib/widgets/profile/profile.dart` *(failed: command not found)*
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5918707c083249962fb4f36d920ea