### PR TITLE
Add refresh control for Truster view

### DIFF
--- a/lib/widgets/truster/trusterview.dart
+++ b/lib/widgets/truster/trusterview.dart
@@ -13,6 +13,13 @@ class TrusterView extends StatefulWidget {
 
 class TrusterViewState extends State<TrusterView> {
   Null get countries => null;
+  int _refreshId = 0;
+
+  void _refreshData() {
+    setState(() {
+      _refreshId++;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -58,8 +65,14 @@ class TrusterViewState extends State<TrusterView> {
                         fontWeight: FontWeight.bold),
                   ),
                   centerTitle: true,
+                  actions: [
+                    IconButton(
+                      icon: const Icon(Icons.refresh, color: Colors.white),
+                      onPressed: _refreshData,
+                    ),
+                  ],
                 ),
-                body: const SingleChildScrollView(
+                body: SingleChildScrollView(
                   child: Center(
                     child: Wrap(
                       alignment: WrapAlignment.spaceBetween,
@@ -72,14 +85,14 @@ class TrusterViewState extends State<TrusterView> {
                         SizedBox(
                           height: 600,
                           width: 600,
-                          child: ReportsWidget(), // Report Overview
+                          child: ReportsWidget(key: ValueKey('reports_$_refreshId')),
                         ),
                         SizedBox(
                           height: 600,
                           width: 600,
-                          child: StatusOverview(),
+                          child: StatusOverview(key: ValueKey('status_$_refreshId')),
                         ),
-                        SizedBox(
+                        const SizedBox(
                           height: 220,
                           width: 600,
                           child: ActionBoard(),


### PR DESCRIPTION
## Summary
- allow refreshing truster reports and status with a new app bar button
- rebuild core truster widgets on refresh to re-query latest data

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4c6695c88324a9c5180543573d41