### PR TITLE
Show upload thumbnail while loading in Postviewer

### DIFF
--- a/lib/widgets/infoscreens/loadingpleasewaitscreen.dart
+++ b/lib/widgets/infoscreens/loadingpleasewaitscreen.dart
@@ -1,9 +1,13 @@
+import 'dart:typed_data';
+
 import 'package:fr0gsite/config.dart';
+import 'package:fr0gsite/ipfsactions.dart';
 import 'package:flutter/material.dart';
 import 'package:lottie/lottie.dart';
 
 class Loadingpleasewaitscreen extends StatelessWidget {
-  const Loadingpleasewaitscreen({super.key});
+  final String? thumbhash;
+  const Loadingpleasewaitscreen({super.key, this.thumbhash});
 
   @override
   Widget build(BuildContext context) {
@@ -27,8 +31,20 @@ class Loadingpleasewaitscreen extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
+            if (thumbhash != null)
+              FutureBuilder<Uint8List>(
+                  future: IPFSActions.fetchipfsdata(context, thumbhash),
+                  builder: (context, snapshot) {
+                    if (snapshot.connectionState == ConnectionState.done &&
+                        snapshot.hasData &&
+                        snapshot.data!.isNotEmpty) {
+                      return Image.memory(snapshot.data!,
+                          height: elementheight * 4);
+                    }
+                    return SizedBox(height: elementheight * 4);
+                  }),
             Lottie.asset('assets/lottie/loadingdots.json',
-                repeat: true, animate: true, height: elementheight * 6),
+                repeat: true, animate: true, height: elementheight * 4),
           ],
         ),
       ),

--- a/lib/widgets/postviewer/swipeitem.dart
+++ b/lib/widgets/postviewer/swipeitem.dart
@@ -108,10 +108,12 @@ class _SwipeItemState extends State<SwipeItem> {
                       ],
                     );
                   } else {
-                    return const Loadingpleasewaitscreen();
+                    return Loadingpleasewaitscreen(
+                        thumbhash: widget.upload.thumbipfshash);
                   }
                 } else {
-                  return const Loadingpleasewaitscreen();
+                  return Loadingpleasewaitscreen(
+                      thumbhash: widget.upload.thumbipfshash);
                 }
               });
         }),


### PR DESCRIPTION
## Summary
- Display upload thumbnail in `Loadingpleasewaitscreen` above loading animation
- Pass the post's thumbnail hash from `SwipeItem` so the preview is shown while content loads

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c00f64d8048324bdf9d2cabf07b334