### PR TITLE
refactor: reuse unified tag widget

### DIFF
--- a/lib/widgets/favorite/favoritetagsview.dart
+++ b/lib/widgets/favorite/favoritetagsview.dart
@@ -3,6 +3,7 @@ import 'package:fr0gsite/chainactions/chainactions.dart';
 import 'package:fr0gsite/datatypes/favoritetag.dart';
 import 'package:fr0gsite/datatypes/globalstatus.dart';
 import 'package:fr0gsite/l10n/app_localizations.dart';
+import 'package:fr0gsite/widgets/home/tagbutton.dart';
 import 'package:provider/provider.dart';
 
 import '../infoscreens/pleaselogin.dart';
@@ -70,18 +71,10 @@ class _FavoriteTagsViewState extends State<FavoriteTagsView> {
                         width: 15,
                       ),
                       // Text button. Go to globaltag page
-                      TextButton(
-                        onPressed: () {
-                          Navigator.pushNamed(context, '/globaltag/${userfavoriteTags[index].globaltagid}',
-                              arguments: userfavoriteTags[index].globaltagid);
-                        },
-                        child: Text(
-                          userfavoriteTags[index].globaltagname,
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontSize: 20,
-                          ),
-                        ),
+                      TagButton(
+                        text: userfavoriteTags[index].globaltagname,
+                        globalTagId: userfavoriteTags[index].globaltagid,
+                        width: null,
                       ),
                     ],
                   ),

--- a/lib/widgets/globaltag/globaltagtopbar.dart
+++ b/lib/widgets/globaltag/globaltagtopbar.dart
@@ -61,7 +61,8 @@ class _GlobalTagTopBarState extends State<GlobalTagTopBar> {
                             Padding(
                               padding: const EdgeInsets.all(8.0),
                               child: TagButton(
-                                  text: globaltag.text, globaltagid: globaltag.globaltagid),
+                                  text: globaltag.text,
+                                  globalTagId: globaltag.globaltagid),
                             ),
                             Tooltip(
                               message: AppLocalizations.of(context)!.addtofavorite,

--- a/lib/widgets/home/populartags.dart
+++ b/lib/widgets/home/populartags.dart
@@ -68,7 +68,7 @@ class _PopulartagsState extends State<Populartags> {
                                     padding: const EdgeInsets.all(8),
                                     child: TagButton(
                                         text: taglist[index * 2].text,
-                                        globaltagid: taglist[index * 2]
+                                        globalTagId: taglist[index * 2]
                                             .globaltagid),
                                   ),
                                   if (index * 2 + 1 < snapshot.data!.length)
@@ -76,7 +76,7 @@ class _PopulartagsState extends State<Populartags> {
                                       padding: const EdgeInsets.all(8.0),
                                       child: TagButton(
                                           text: taglist[index * 2 + 1].text,
-                                          globaltagid: taglist[index * 2 + 1]
+                                          globalTagId: taglist[index * 2 + 1]
                                               .globaltagid),
                                     ),
                                 ],

--- a/lib/widgets/home/tagbutton.dart
+++ b/lib/widgets/home/tagbutton.dart
@@ -3,46 +3,85 @@ import 'package:flutter/material.dart';
 import 'package:fr0gsite/config.dart';
 import 'package:fr0gsite/widgets/home/octagonborder.dart';
 
-class TagButton extends StatefulWidget {
-  const TagButton({super.key, required this.text, required this.globaltagid});
+class TagButton extends StatelessWidget {
+  const TagButton({
+    super.key,
+    required this.text,
+    this.globalTagId,
+    this.onPressed,
+    this.arguments,
+    this.width = 150,
+    this.height = 35,
+    this.tooltipThreshold = 17,
+    this.textStyle,
+    this.contentPadding = const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+  });
 
   final String text;
-  final BigInt globaltagid;
-
-  @override
-  State<TagButton> createState() => TagButtonState();
-}
-
-class TagButtonState extends State<TagButton> {
-  double tagwidth = 150;
+  final Object? globalTagId;
+  final VoidCallback? onPressed;
+  final Object? arguments;
+  final double? width;
+  final double? height;
+  final int tooltipThreshold;
+  final TextStyle? textStyle;
+  final EdgeInsetsGeometry contentPadding;
 
   @override
   Widget build(BuildContext context) {
-    return Tooltip(
-      message: widget.text.length > 17 ? widget.text : '',
-      child: MaterialButton(
-        onPressed: () {
-          debugPrint('Show Globaltag ${widget.text} ');
-          Navigator.pushNamed(context, '/globaltag/${widget.globaltagid}',
-              arguments: {'text': widget.text, 'globaltagid': widget.globaltagid});
-        },
-        shape: const OctagonBorder(),
-        color: AppColor.tagcolor,
+    final bool shouldShowTooltip =
+        tooltipThreshold >= 0 && text.length > tooltipThreshold;
+
+    Widget button = Material(
+      shape: const OctagonBorder(),
+      color: AppColor.tagcolor,
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        customBorder: const OctagonBorder(),
+        onTap: _hasTapHandler ? () => _handleTap(context) : null,
         hoverColor: Colors.blue,
-        child: SizedBox(
-          width: tagwidth,
-          height: 35,
-          child: Align(
-            alignment: Alignment.center,
-            child: Text(
-              widget.text,
-              textAlign: TextAlign.center,
-              overflow: TextOverflow.ellipsis,
-              style: const TextStyle(color: Colors.white),
-            ),
+        child: Container(
+          padding: contentPadding,
+          alignment: Alignment.center,
+          constraints: BoxConstraints.tightFor(
+            width: width,
+            height: height,
+          ),
+          child: Text(
+            text,
+            textAlign: TextAlign.center,
+            overflow: TextOverflow.ellipsis,
+            style: textStyle ?? const TextStyle(color: Colors.white),
           ),
         ),
       ),
     );
+
+    if (shouldShowTooltip) {
+      button = Tooltip(
+        message: text,
+        child: button,
+      );
+    }
+
+    return button;
+  }
+
+  bool get _hasTapHandler => onPressed != null || globalTagId != null;
+
+  void _handleTap(BuildContext context) {
+    if (onPressed != null) {
+      onPressed!();
+      return;
+    }
+
+    if (globalTagId != null) {
+      final String routeId = globalTagId.toString();
+      Navigator.pushNamed(
+        context,
+        '/globaltag/$routeId',
+        arguments: arguments ?? {'text': text, 'globaltagid': globalTagId},
+      );
+    }
   }
 }

--- a/lib/widgets/postviewer/tagelemente.dart
+++ b/lib/widgets/postviewer/tagelemente.dart
@@ -1,6 +1,6 @@
 import 'package:fr0gsite/chainactions/chainactions.dart';
-import 'package:fr0gsite/config.dart';
 import 'package:fr0gsite/datatypes/globalstatus.dart';
+import 'package:fr0gsite/widgets/home/tagbutton.dart';
 import 'package:fr0gsite/widgets/login/login.dart';
 import 'package:fr0gsite/widgets/postviewer/commentandtagbutton.dart';
 import 'package:flutter/material.dart';
@@ -29,25 +29,11 @@ class _TagelementState extends State<Tagelement> {
       commentandtagbutton(widget.globuptagid, Icons.do_not_disturb_on_outlined,
           "Downvote", downvotetag, false, 0, Colors.red, Colors.orange),
       const SizedBox(width: 5),
-      TextButton(
-        onPressed: () {
-          Navigator.pushNamed(context, '/globaltag/${widget.globaltagid}',
-              arguments: {
-                'text': widget.tagtext,
-                'globaltagid': widget.globaltagid
-              });
-        },
-        style: ButtonStyle(
-          backgroundColor: WidgetStateProperty.all<Color>(AppColor.tagcolor),
-          overlayColor: WidgetStateColor.resolveWith((states) => Colors.blue),
-          shape: WidgetStateProperty.all<RoundedRectangleBorder>(
-              RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10.0),
-                  side: const BorderSide(color: Colors.black))),
-        ),
-        child:
-            Text(widget.tagtext, style: const TextStyle(color: Colors.white)),
-      )
+      TagButton(
+        text: widget.tagtext,
+        globalTagId: widget.globaltagid,
+        width: null,
+      ),
     ]);
   }
 


### PR DESCRIPTION
## Summary
- replace the old stateful TagButton implementation with a reusable stateless widget that centralises tag styling and navigation
- use the unified TagButton in the post viewer tag list, favourites screen, global tag header, and popular tags list so tags share the same appearance everywhere

## Testing
- not run (flutter command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c9f1b9aea883249553da539afe8450