### PR TITLE
Add hero animation to tag button transitions

### DIFF
--- a/lib/widgets/globaltag/globaltagtopbar.dart
+++ b/lib/widgets/globaltag/globaltagtopbar.dart
@@ -30,6 +30,10 @@ class _GlobalTagTopBarState extends State<GlobalTagTopBar> {
   void initState() {
     super.initState();
     globaltag.text = widget.tagtext;
+    if (widget.globaltagid.isNotEmpty) {
+      globaltag.globaltagid =
+          BigInt.tryParse(widget.globaltagid) ?? globaltag.globaltagid;
+    }
     futuregetglobaltag = getglobaltag();
     checkifuserhasfavoritedtag();
   }
@@ -61,7 +65,9 @@ class _GlobalTagTopBarState extends State<GlobalTagTopBar> {
                             Padding(
                               padding: const EdgeInsets.all(8.0),
                               child: TagButton(
-                                  text: globaltag.text, globaltagid: globaltag.globaltagid),
+                                  text: globaltag.text,
+                                  globaltagid: globaltag.globaltagid,
+                                  heroTag: 'globaltag-${widget.globaltagid}'),
                             ),
                             Tooltip(
                               message: AppLocalizations.of(context)!.addtofavorite,

--- a/lib/widgets/home/populartags.dart
+++ b/lib/widgets/home/populartags.dart
@@ -69,7 +69,9 @@ class _PopulartagsState extends State<Populartags> {
                                     child: TagButton(
                                         text: taglist[index * 2].text,
                                         globaltagid: taglist[index * 2]
-                                            .globaltagid),
+                                            .globaltagid,
+                                        heroTag:
+                                            'globaltag-${taglist[index * 2].globaltagid}'),
                                   ),
                                   if (index * 2 + 1 < snapshot.data!.length)
                                     Padding(
@@ -77,7 +79,9 @@ class _PopulartagsState extends State<Populartags> {
                                       child: TagButton(
                                           text: taglist[index * 2 + 1].text,
                                           globaltagid: taglist[index * 2 + 1]
-                                              .globaltagid),
+                                              .globaltagid,
+                                          heroTag:
+                                              'globaltag-${taglist[index * 2 + 1].globaltagid}'),
                                     ),
                                 ],
                               ),

--- a/lib/widgets/home/tagbutton.dart
+++ b/lib/widgets/home/tagbutton.dart
@@ -4,10 +4,16 @@ import 'package:fr0gsite/config.dart';
 import 'package:fr0gsite/widgets/home/octagonborder.dart';
 
 class TagButton extends StatefulWidget {
-  const TagButton({super.key, required this.text, required this.globaltagid});
+  const TagButton({
+    super.key,
+    required this.text,
+    required this.globaltagid,
+    this.heroTag,
+  });
 
   final String text;
   final BigInt globaltagid;
+  final Object? heroTag;
 
   @override
   State<TagButton> createState() => TagButtonState();
@@ -18,31 +24,43 @@ class TagButtonState extends State<TagButton> {
 
   @override
   Widget build(BuildContext context) {
-    return Tooltip(
-      message: widget.text.length > 17 ? widget.text : '',
-      child: MaterialButton(
-        onPressed: () {
-          debugPrint('Show Globaltag ${widget.text} ');
-          Navigator.pushNamed(context, '/globaltag/${widget.globaltagid}',
-              arguments: {'text': widget.text, 'globaltagid': widget.globaltagid});
-        },
-        shape: const OctagonBorder(),
-        color: AppColor.tagcolor,
-        hoverColor: Colors.blue,
-        child: SizedBox(
-          width: tagwidth,
-          height: 35,
-          child: Align(
-            alignment: Alignment.center,
-            child: Text(
-              widget.text,
-              textAlign: TextAlign.center,
-              overflow: TextOverflow.ellipsis,
-              style: const TextStyle(color: Colors.white),
-            ),
+    Widget button = MaterialButton(
+      onPressed: () {
+        debugPrint('Show Globaltag ${widget.text} ');
+        Navigator.pushNamed(context, '/globaltag/${widget.globaltagid}',
+            arguments: {'text': widget.text, 'globaltagid': widget.globaltagid});
+      },
+      shape: const OctagonBorder(),
+      color: AppColor.tagcolor,
+      hoverColor: Colors.blue,
+      child: SizedBox(
+        width: tagwidth,
+        height: 35,
+        child: Align(
+          alignment: Alignment.center,
+          child: Text(
+            widget.text,
+            textAlign: TextAlign.center,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(color: Colors.white),
           ),
         ),
       ),
+    );
+
+    if (widget.heroTag != null) {
+      button = Hero(
+        tag: widget.heroTag!,
+        child: Material(
+          type: MaterialType.transparency,
+          child: button,
+        ),
+      );
+    }
+
+    return Tooltip(
+      message: widget.text.length > 17 ? widget.text : '',
+      child: button,
     );
   }
 }


### PR DESCRIPTION
## Summary
- wrap TagButton contents with an optional Hero to animate navigation between routes
- provide consistent hero tags on popular tag lists and the global tag top bar
- ensure the global tag top bar initializes its tag id before async data loads

## Testing
- Not run (flutter command not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cb0d810a74832497fbf10effdfb617