### PR TITLE
Display sound slider values as percentages

### DIFF
--- a/lib/widgets/postviewer/soundbar.dart
+++ b/lib/widgets/postviewer/soundbar.dart
@@ -64,6 +64,16 @@ class _SoundBarState extends State<SoundBar> {
                 max: 1,
                 min: 0,
                 rtl: true,
+                tooltip: FlutterSliderTooltip(
+                  format: (String value) {
+                    final parsedValue = double.tryParse(value);
+                    if (parsedValue == null) {
+                      return value;
+                    }
+                    final percentValue = (parsedValue * 100).round();
+                    return '$percentValue %';
+                  },
+                ),
                 trackBar: FlutterSliderTrackBar(
                   activeTrackBarHeight: 15,
                   inactiveTrackBarHeight: 15,


### PR DESCRIPTION
## Summary
- format the post viewer sound slider tooltip to show whole-number percentages instead of decimal values

## Testing
- Not run (Flutter SDK is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cb0de68a648324af1098bc6a5fe12d