### PR TITLE
Refactor tag presentation to use shared widget

### DIFF
--- a/lib/widgets/favorite/favoritetagsview.dart
+++ b/lib/widgets/favorite/favoritetagsview.dart
@@ -5,6 +5,8 @@ import 'package:fr0gsite/datatypes/globalstatus.dart';
 import 'package:fr0gsite/l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 
+import 'package:fr0gsite/widgets/home/tagbutton.dart';
+
 import '../infoscreens/pleaselogin.dart';
 
 class FavoriteTagsView extends StatefulWidget {
@@ -70,19 +72,15 @@ class _FavoriteTagsViewState extends State<FavoriteTagsView> {
                         width: 15,
                       ),
                       // Text button. Go to globaltag page
-                      TextButton(
-                        onPressed: () {
-                          Navigator.pushNamed(context, '/globaltag/${userfavoriteTags[index].globaltagid}',
-                              arguments: userfavoriteTags[index].globaltagid);
-                        },
-                        child: Text(
-                          userfavoriteTags[index].globaltagname,
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontSize: 20,
-                          ),
+                      Expanded(
+                        child: TagButton(
+                          text: userfavoriteTags[index].globaltagname,
+                          globaltagid: userfavoriteTags[index].globaltagid,
+                          heroTag:
+                              'favorite-tag-${userfavoriteTags[index].globaltagid.toString()}',
+                          height: 40,
                         ),
-                      ),
+                      )
                     ],
                   ),
                 );

--- a/lib/widgets/home/populartags.dart
+++ b/lib/widgets/home/populartags.dart
@@ -70,6 +70,7 @@ class _PopulartagsState extends State<Populartags> {
                                         text: taglist[index * 2].text,
                                         globaltagid: taglist[index * 2]
                                             .globaltagid,
+                                        width: tagwidth,
                                         heroTag:
                                             'globaltag-${taglist[index * 2].globaltagid}'),
                                   ),
@@ -80,6 +81,7 @@ class _PopulartagsState extends State<Populartags> {
                                           text: taglist[index * 2 + 1].text,
                                           globaltagid: taglist[index * 2 + 1]
                                               .globaltagid,
+                                          width: tagwidth,
                                           heroTag:
                                               'globaltag-${taglist[index * 2 + 1].globaltagid}'),
                                     ),

--- a/lib/widgets/home/tagbutton.dart
+++ b/lib/widgets/home/tagbutton.dart
@@ -3,54 +3,56 @@ import 'package:flutter/material.dart';
 import 'package:fr0gsite/config.dart';
 import 'package:fr0gsite/widgets/home/octagonborder.dart';
 
-class TagButton extends StatefulWidget {
+class TagButton extends StatelessWidget {
   const TagButton({
     super.key,
     required this.text,
     required this.globaltagid,
     this.heroTag,
+    this.onPressed,
+    this.width,
+    this.height = 35,
+    this.padding = const EdgeInsets.symmetric(horizontal: 12),
+    this.tooltipThreshold = 17,
   });
 
   final String text;
   final BigInt globaltagid;
   final Object? heroTag;
-
-  @override
-  State<TagButton> createState() => TagButtonState();
-}
-
-class TagButtonState extends State<TagButton> {
-  double tagwidth = 150;
+  final VoidCallback? onPressed;
+  final double? width;
+  final double height;
+  final EdgeInsetsGeometry padding;
+  final int tooltipThreshold;
 
   @override
   Widget build(BuildContext context) {
     Widget button = MaterialButton(
-      onPressed: () {
-        debugPrint('Show Globaltag ${widget.text} ');
-        Navigator.pushNamed(context, '/globaltag/${widget.globaltagid}',
-            arguments: {'text': widget.text, 'globaltagid': widget.globaltagid});
-      },
+      onPressed: onPressed ?? () => _navigateToTag(context),
       shape: const OctagonBorder(),
       color: AppColor.tagcolor,
       hoverColor: Colors.blue,
+      padding: EdgeInsets.zero,
       child: SizedBox(
-        width: tagwidth,
-        height: 35,
-        child: Align(
-          alignment: Alignment.center,
-          child: Text(
-            widget.text,
-            textAlign: TextAlign.center,
-            overflow: TextOverflow.ellipsis,
-            style: const TextStyle(color: Colors.white),
+        width: width,
+        height: height,
+        child: Center(
+          child: Padding(
+            padding: padding,
+            child: Text(
+              text,
+              textAlign: TextAlign.center,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(color: Colors.white),
+            ),
           ),
         ),
       ),
     );
 
-    if (widget.heroTag != null) {
+    if (heroTag != null) {
       button = Hero(
-        tag: widget.heroTag!,
+        tag: heroTag!,
         child: Material(
           type: MaterialType.transparency,
           child: button,
@@ -59,8 +61,14 @@ class TagButtonState extends State<TagButton> {
     }
 
     return Tooltip(
-      message: widget.text.length > 17 ? widget.text : '',
+      message: text.length > tooltipThreshold ? text : '',
       child: button,
     );
+  }
+
+  void _navigateToTag(BuildContext context) {
+    debugPrint('Show Globaltag $text ');
+    Navigator.pushNamed(context, '/globaltag/$globaltagid',
+        arguments: {'text': text, 'globaltagid': globaltagid});
   }
 }

--- a/lib/widgets/postviewer/tagelemente.dart
+++ b/lib/widgets/postviewer/tagelemente.dart
@@ -1,8 +1,8 @@
 import 'package:fr0gsite/chainactions/chainactions.dart';
-import 'package:fr0gsite/config.dart';
 import 'package:fr0gsite/datatypes/globalstatus.dart';
 import 'package:fr0gsite/widgets/login/login.dart';
 import 'package:fr0gsite/widgets/postviewer/commentandtagbutton.dart';
+import 'package:fr0gsite/widgets/home/tagbutton.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -23,31 +23,18 @@ class Tagelement extends StatefulWidget {
 class _TagelementState extends State<Tagelement> {
   @override
   Widget build(BuildContext context) {
+    final BigInt globalTagId = BigInt.parse(widget.globaltagid);
     return Row(children: [
       commentandtagbutton(widget.globuptagid, Icons.add_circle_outline_sharp,
           "Upvote", upvotetag, false, 0, Colors.green, Colors.orange),
       commentandtagbutton(widget.globuptagid, Icons.do_not_disturb_on_outlined,
           "Downvote", downvotetag, false, 0, Colors.red, Colors.orange),
       const SizedBox(width: 5),
-      TextButton(
-        onPressed: () {
-          Navigator.pushNamed(context, '/globaltag/${widget.globaltagid}',
-              arguments: {
-                'text': widget.tagtext,
-                'globaltagid': widget.globaltagid
-              });
-        },
-        style: ButtonStyle(
-          backgroundColor: WidgetStateProperty.all<Color>(AppColor.tagcolor),
-          overlayColor: WidgetStateColor.resolveWith((states) => Colors.blue),
-          shape: WidgetStateProperty.all<RoundedRectangleBorder>(
-              RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10.0),
-                  side: const BorderSide(color: Colors.black))),
-        ),
-        child:
-            Text(widget.tagtext, style: const TextStyle(color: Colors.white)),
-      )
+      TagButton(
+        text: widget.tagtext,
+        globaltagid: globalTagId,
+        heroTag: 'globaltag-${widget.globaltagid}',
+      ),
     ]);
   }
 

--- a/lib/widgets/truster/trustervotereportview.dart
+++ b/lib/widgets/truster/trustervotereportview.dart
@@ -12,6 +12,7 @@ import 'package:fr0gsite/datatypes/upload.dart';
 import 'package:fr0gsite/globalnotifications.dart';
 import 'package:fr0gsite/nameconverter.dart';
 import 'package:fr0gsite/widgets/cube/cube.dart';
+import 'package:fr0gsite/widgets/home/tagbutton.dart';
 import 'package:fr0gsite/l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 
@@ -231,22 +232,12 @@ class _TrusterVoteReportViewState extends State<TrusterVoteReportView> {
                   ),
                 ),
                 const SizedBox(height: 12),
-                Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                  decoration: BoxDecoration(
-                    color: Colors.blue.withAlpha((0.3 * 255).toInt()),
-                    borderRadius: BorderRadius.circular(16),
-                    border: Border.all(color: Colors.blue, width: 1),
-                  ),
-                  child: Text(
-                    tag.text,
-                    style: const TextStyle(
-                      color: Colors.white,
-                      fontSize: 16,
-                      fontWeight: FontWeight.bold,
-                    ),
-                    textAlign: TextAlign.center,
-                  ),
+                TagButton(
+                  text: tag.text,
+                  globaltagid: tag.globaltagid,
+                  height: 40,
+                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                  heroTag: 'report-tag-${tag.globaltagid}',
                 ),
               ],
             ),


### PR DESCRIPTION
## Summary
- convert the tag button into a reusable, configurable widget so it can be shared across the app
- replace bespoke tag UI in the favorites list, post viewer, and truster report views with the shared widget for consistent styling
- keep the home popular tags list aligned by specifying widths on the shared widget instances

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d02242e0588324aac88ab6bcc16cf1